### PR TITLE
feat: add Docker Compose setup for SBCL/Swank and PlantUML server

### DIFF
--- a/docker/plantuml-server/docker-compose.yml
+++ b/docker/plantuml-server/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  plantuml-server:
+    image: plantuml/plantuml-server:jetty
+    ports:
+      - "127.0.0.1:8080:8080"
+    restart: unless-stopped

--- a/docker/sbcl-swank/Dockerfile
+++ b/docker/sbcl-swank/Dockerfile
@@ -1,0 +1,27 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    sbcl \
+    curl \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Quicklisp
+RUN curl -fsSL -o /tmp/ql.lisp https://beta.quicklisp.org/quicklisp.lisp && \
+    sbcl --non-interactive \
+         --load /tmp/ql.lisp \
+         --eval '(quicklisp-quickstart:install :path "/root/quicklisp")' \
+         --eval '(ql:add-to-init-file)' && \
+    rm /tmp/ql.lisp
+
+# Pre-fetch Swank so first startup is fast
+RUN sbcl --non-interactive --eval '(ql:quickload :swank)' --eval '(quit)'
+
+WORKDIR /lisp
+
+EXPOSE 4005
+
+CMD ["sbcl", \
+     "--eval", "(ql:quickload :swank)", \
+     "--eval", "(swank:create-server :port 4005 :dont-close t)", \
+     "--eval", "(loop (sleep 60))"]

--- a/docker/sbcl-swank/docker-compose.yml
+++ b/docker/sbcl-swank/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  sbcl-swank:
+    build: .
+    ports:
+      - "127.0.0.1:4005:4005"
+    volumes:
+      # Mount your project directory into /lisp inside the container.
+      # Override with: LISP_DIR=/path/to/project docker compose up
+      - "${LISP_DIR:-$PWD}:/lisp"
+    restart: unless-stopped

--- a/docs/diagrams.md
+++ b/docs/diagrams.md
@@ -17,20 +17,34 @@ Treesitter parsers (`markdown`, `markdown_inline`, `plantuml`) provide syntax hi
 
 | Dependency | Purpose | Install hint |
 |---|---|---|
-| **PlantUML Docker server** | Render `.puml` diagrams | `docker run -d -p 8080:8080 plantuml/plantuml-server` |
+| **PlantUML Docker server** | Render `.puml` diagrams | See [Docker setup](#starting-the-plantuml-server) below |
 | **Node.js / npm** | Build step for markdown-preview.nvim | `sudo apt install nodejs npm` |
 | **python3** | Encode `.puml` buffers for the server API | Pre-installed on most Linux distros |
 | **xdg-open** | Open rendered diagram URLs in the browser | Pre-installed on most Linux desktops |
 | **marksman** *(optional)* | Markdown LSP | `sudo apt install marksman` / `brew install marksman` |
 
+## Starting the PlantUML Server
+
+A Docker Compose file is provided at `docker/plantuml-server/docker-compose.yml` using the `plantuml/plantuml-server:jetty` image. Port 8080 is bound to localhost only.
+
+```sh
+# Pull and start (runs in the background):
+docker compose -f ~/.config/nvim/docker/plantuml-server/docker-compose.yml up -d
+
+# Stop it when done:
+docker compose -f ~/.config/nvim/docker/plantuml-server/docker-compose.yml down
+```
+
+The server is stateless — no build step or volume is needed. It will be available at `http://localhost:8080` immediately after startup.
+
 ## Quick Start
 
 ### Markdown with embedded PlantUML
 
-1. Start your PlantUML Docker server:
+1. Start the PlantUML server (if not already running):
 
    ```sh
-   docker run -d -p 8080:8080 plantuml/plantuml-server
+   docker compose -f ~/.config/nvim/docker/plantuml-server/docker-compose.yml up -d
    ```
 
 2. Open (or create) a Markdown file:
@@ -59,7 +73,9 @@ Treesitter parsers (`markdown`, `markdown_inline`, `plantuml`) provide syntax hi
 
 ### Standalone `.puml` files
 
-1. Open or create a `.puml` file:
+1. Ensure the PlantUML server is running (see [Starting the PlantUML Server](#starting-the-plantuml-server)).
+
+2. Open or create a `.puml` file:
 
    ```sh
    nvim sequence.puml

--- a/docs/lisp.md
+++ b/docs/lisp.md
@@ -21,6 +21,24 @@ The `cl_lsp` server is configured in `lua/config/lsp.lua` for Common Lisp. Insta
 
 1. **Start your REPL** in a terminal (Conjure connects to it):
 
+   **Option A — Docker (recommended for Common Lisp):**
+   A pre-configured Docker setup lives in `docker/sbcl-swank/`. It runs SBCL with Quicklisp and starts the Swank server on port 4005 automatically.
+
+   ```sh
+   # Build the image once:
+   docker compose -f ~/.config/nvim/docker/sbcl-swank/docker-compose.yml build
+
+   # Start the server, mounting your project directory into /lisp inside the container:
+   LISP_DIR=$PWD docker compose -f ~/.config/nvim/docker/sbcl-swank/docker-compose.yml up -d
+
+   # Stop it when done:
+   LISP_DIR=$PWD docker compose -f ~/.config/nvim/docker/sbcl-swank/docker-compose.yml down
+   ```
+
+   Conjure will auto-connect on the next file open, or use `,cc` to connect manually.
+
+   **Option B — local SBCL:**
+
    ```sh
    # Common Lisp (SBCL via Swank)
    sbcl --load ~/.quicklisp/setup.lisp --eval '(ql:quickload :swank)' --eval '(swank:create-server :dont-close t)'
@@ -70,7 +88,13 @@ The `cl_lsp` server is configured in `lua/config/lsp.lua` for Common Lisp. Insta
 
 6. **Stop the Swank server** when you are done (Common Lisp only):
 
-   From within Neovim, evaluate the following with `,ee` (cursor on the form) or `,eb` (entire buffer):
+   If using **Docker**, stop the container:
+
+   ```sh
+   LISP_DIR=$PWD docker compose -f ~/.config/nvim/docker/sbcl-swank/docker-compose.yml down
+   ```
+
+   If running **SBCL locally**, evaluate the following with `,ee` (cursor on the form) or `,eb` (entire buffer):
 
    ```lisp
    (swank:stop-server 4005)
@@ -86,9 +110,9 @@ The `cl_lsp` server is configured in `lua/config/lsp.lua` for Common Lisp. Insta
 
 ```
  ┌──────────────────────────────────────────────┐
- │  Terminal A: REPL server (SBCL/nREPL/etc.)   │
+ │  Docker: sbcl-swank (or local REPL server)   │
  └──────────────────────────────────────────────┘
-         ▲  Conjure connects automatically
+         ▲  Conjure connects on 127.0.0.1:4005
          │
  ┌──────────────────────────────────────────────┐
  │  Neovim                                      │


### PR DESCRIPTION
- Add docker/sbcl-swank/ with Dockerfile (SBCL + Quicklisp + Swank) and docker-compose.yml binding port 4005 to localhost
- Add docker/plantuml-server/docker-compose.yml using plantuml/plantuml-server:jetty, binding port 8080 to localhost
- Update docs/lisp.md: Docker option (recommended) for Quick Start, compose down instructions for stopping Swank
- Update docs/diagrams.md: dedicated 'Starting the PlantUML Server' section, replace bare docker run with compose commands throughout