### PR TITLE
feat(confluence): add Confluence publish integration

### DIFF
--- a/after/ftplugin/markdown.lua
+++ b/after/ftplugin/markdown.lua
@@ -15,3 +15,7 @@ vim.keymap.set("n", "<localleader>md", "<cmd>MarpToPdf<cr>", { buffer = true, de
 -- Markdown → PDF with PlantUML diagrams (requires Docker; see docs/guides/diagrams.md)
 require("config.mdpdf").setup()
 vim.keymap.set("n", "<localleader>dp", "<cmd>MdToPdf<cr>", { buffer = true, desc = "Export markdown to PDF with PlantUML diagrams" })
+
+-- Confluence publish (requires CONFLUENCE_EMAIL + CONFLUENCE_API_TOKEN env vars; see docs/guides/confluence.md)
+require("config.confluence").setup()
+vim.keymap.set("n", "<localleader>cc", "<cmd>MdToConfluence<cr>", { buffer = true, desc = "Publish to Confluence" })

--- a/docs/guides/confluence.md
+++ b/docs/guides/confluence.md
@@ -1,0 +1,107 @@
+# Confluence Publishing Guide
+
+Publish a local markdown file directly to its Confluence page with `,cc` (or `:MdToConfluence`).
+
+The publisher converts the markdown to Confluence storage format via pandoc, renders PlantUML diagrams to inline PNG images via the local PlantUML server, and updates the Confluence page via the REST API.
+
+---
+
+## Prerequisites
+
+| Dependency | Purpose | Install hint |
+|---|---|---|
+| **pandoc** | Markdown → HTML conversion | `sudo apt install pandoc` |
+| **python3** | Runs the publish script | Pre-installed on most systems |
+| **PlantUML server** *(optional)* | Renders diagrams to PNG | See [diagrams.md](diagrams.md) |
+| **CONFLUENCE_EMAIL** env var | Atlassian account email | See [Authentication](#authentication) |
+| **CONFLUENCE_API_TOKEN** env var | Atlassian API token | See [Authentication](#authentication) |
+
+---
+
+## Authentication
+
+The publisher reads credentials from environment variables. They are never stored in any file.
+
+### Generating an API token
+
+1. Go to <https://id.atlassian.com/manage-profile/security/api-tokens>
+2. Click **Create API token**
+3. Give it a label (e.g. `nvim-confluence-publish`) and copy the token
+
+### Setting the environment variables
+
+Add these lines to your shell profile (`~/.bashrc`, `~/.zshrc`, or `~/.profile`):
+
+```sh
+export CONFLUENCE_EMAIL="your.email@example.com"
+export CONFLUENCE_API_TOKEN="your-api-token-here"
+```
+
+Reload your shell or open a new terminal. Neovim must be launched from a shell that has these variables set.
+
+> **Never commit these values to any file.** Environment variables in your shell profile are not version controlled and are not visible to other processes.
+
+---
+
+## Page map
+
+The publisher resolves which Confluence page to update by reading `docs/confluence-page-map.md` at the root of the git repository containing the open file.
+
+Each entry maps a local file path (relative to `docs/`) to its Confluence page URL:
+
+```markdown
+| `lld/0015/0015a_licence-data-persistence-and-synchronisation.md` | DRIVER-LLD-0015: Licence Data Persistence | https://novascotia-rmvmt.atlassian.net/wiki/spaces/ROAD/pages/172065288/... | |
+```
+
+If the current file is not in the page map, the command reports an error and does nothing.
+
+---
+
+## Usage
+
+Open any markdown file that is listed in the page map, then:
+
+| Method | Action |
+|---|---|
+| `,cc` | Publish current file to Confluence |
+| `:MdToConfluence` | Same, via command |
+
+Progress messages appear in the notification area. The final message includes the published page URL.
+
+---
+
+## Diagram rendering
+
+PlantUML fenced blocks are rendered to PNG via the local PlantUML server (`http://localhost:8080` by default) and embedded as inline base64 images in the Confluence page.
+
+If the PlantUML server is not running, the block falls back to a Confluence code macro — the diagram source is preserved but not rendered.
+
+To override the server URL:
+
+```sh
+export PLANTUML_SERVER="http://localhost:8080"
+```
+
+---
+
+## Publish script
+
+The conversion and upload logic lives in `scripts/confluence_publish.py` at the repository root. It can also be run directly from the terminal:
+
+```sh
+CONFLUENCE_EMAIL="..." CONFLUENCE_API_TOKEN="..." \
+  python3 scripts/confluence_publish.py docs/lld/0015/0015a_licence-data-persistence-and-synchronisation.md
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `CONFLUENCE_EMAIL and CONFLUENCE_API_TOKEN must be set` | Env vars missing | Add to shell profile; relaunch Neovim |
+| `not found in confluence-page-map.md` | File not in page map | Add an entry to `docs/confluence-page-map.md` |
+| `GET .../content/... → 401` | Invalid credentials | Regenerate API token at id.atlassian.com |
+| `GET .../content/... → 403` | Token lacks page edit permission | Check Confluence space permissions |
+| `pandoc failed` | pandoc not installed | `sudo apt install pandoc` |
+| Diagrams appear as code blocks | PlantUML server not running | Start the PlantUML Docker container |

--- a/lua/config/confluence.lua
+++ b/lua/config/confluence.lua
@@ -1,0 +1,144 @@
+-- lua/config/confluence.lua
+--
+-- Publish the current markdown buffer to its Confluence page via the
+-- Confluence REST API.
+--
+-- Requires:
+--   CONFLUENCE_EMAIL       env var  — your Atlassian account email
+--   CONFLUENCE_API_TOKEN   env var  — your Atlassian API token
+--   pandoc                          — markdown → HTML conversion
+--   python3                         — runs the publish script
+--
+-- The publish script is located at scripts/confluence_publish.py in the
+-- git repository root of the currently open file. The Confluence page is
+-- resolved from docs/confluence-page-map.md in the same repository.
+--
+-- See docs/guides/confluence.md for full setup instructions.
+
+local M = {}
+
+--- Find the git repository root from the given path.
+local function find_git_root(dir)
+  local result = vim.fn.systemlist(
+    "git -C " .. vim.fn.shellescape(dir) .. " rev-parse --show-toplevel 2>/dev/null"
+  )
+  if vim.v.shell_error ~= 0 or #result == 0 then
+    return nil
+  end
+  return result[1]
+end
+
+--- Locate the confluence_publish.py script in the repository.
+local function find_publish_script(git_root)
+  local path = git_root .. "/scripts/confluence_publish.py"
+  if vim.fn.filereadable(path) == 1 then
+    return path
+  end
+  return nil
+end
+
+--- Publish the current buffer to its Confluence page.
+function M.publish()
+  local file = vim.fn.expand("%:p")
+
+  if file == "" then
+    vim.notify("Confluence: buffer has no file", vim.log.levels.WARN)
+    return
+  end
+
+  if not file:match("%.md$") then
+    vim.notify("Confluence: not a markdown file", vim.log.levels.WARN)
+    return
+  end
+
+  -- Verify environment variables are present before launching the job.
+  -- The script performs the same check; this gives a faster, clearer message.
+  local email = os.getenv("CONFLUENCE_EMAIL")
+  local token = os.getenv("CONFLUENCE_API_TOKEN")
+  if not email or email == "" or not token or token == "" then
+    vim.notify(
+      "Confluence: CONFLUENCE_EMAIL and CONFLUENCE_API_TOKEN must be set.\n"
+        .. "See docs/guides/confluence.md for setup instructions.",
+      vim.log.levels.ERROR
+    )
+    return
+  end
+
+  local dir      = vim.fn.expand("%:p:h")
+  local git_root = find_git_root(dir)
+  if not git_root then
+    vim.notify("Confluence: file is not inside a git repository", vim.log.levels.ERROR)
+    return
+  end
+
+  local script = find_publish_script(git_root)
+  if not script then
+    vim.notify(
+      "Confluence: publish script not found.\n"
+        .. "Expected: " .. git_root .. "/scripts/confluence_publish.py",
+      vim.log.levels.ERROR
+    )
+    return
+  end
+
+  local filename = vim.fn.expand("%:t")
+  vim.notify("Confluence: publishing " .. filename .. "…", vim.log.levels.INFO)
+
+  local cmd = "python3 "
+    .. vim.fn.shellescape(script)
+    .. " "
+    .. vim.fn.shellescape(file)
+
+  local output_lines = {}
+
+  vim.fn.jobstart(cmd, {
+    stdout_buffered = true,
+    stderr_buffered = true,
+
+    on_stdout = function(_, data)
+      for _, line in ipairs(data) do
+        local l = line:match("^%s*(.-)%s*$")
+        if l ~= "" then
+          table.insert(output_lines, l)
+          vim.notify("Confluence: " .. l, vim.log.levels.INFO)
+        end
+      end
+    end,
+
+    on_stderr = function(_, data)
+      for _, line in ipairs(data) do
+        local l = line:match("^%s*(.-)%s*$")
+        if l ~= "" then
+          vim.notify("Confluence: " .. l, vim.log.levels.ERROR)
+        end
+      end
+    end,
+
+    on_exit = function(_, code)
+      if code == 0 then
+        vim.notify("Confluence: " .. filename .. " published successfully.", vim.log.levels.INFO)
+      else
+        vim.notify(
+          "Confluence: publish failed (exit " .. code .. "). Check the messages above.",
+          vim.log.levels.ERROR
+        )
+      end
+    end,
+  })
+end
+
+--- Register the MdToConfluence user command. Safe to call multiple times.
+function M.setup()
+  if M._loaded then
+    return
+  end
+  M._loaded = true
+
+  vim.api.nvim_create_user_command(
+    "MdToConfluence",
+    M.publish,
+    { desc = "Publish current markdown file to its Confluence page" }
+  )
+end
+
+return M

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ On first launch, [lazy.nvim](https://github.com/folke/lazy.nvim) will bootstrap 
 [Nerd Font]: https://www.nerdfonts.com/
 
 Language-specific prerequisites (LSP servers, REPLs, runtimes) are documented in each language guide:
-[Markdown](docs/guides/markdown.md) · [Diagrams](docs/guides/diagrams.md) · [F#](docs/guides/fsharp.md) · [Haskell](docs/guides/haskell.md) · [Lisp / Clojure / Scheme](docs/guides/lisp.md) · [Presentations / MARP](docs/guides/presentations.md) · [REST Client](docs/guides/rest.md)
+[Markdown](docs/guides/markdown.md) · [Diagrams](docs/guides/diagrams.md) · [Confluence](docs/guides/confluence.md) · [F#](docs/guides/fsharp.md) · [Haskell](docs/guides/haskell.md) · [Lisp / Clojure / Scheme](docs/guides/lisp.md) · [Presentations / MARP](docs/guides/presentations.md) · [REST Client](docs/guides/rest.md)
 
 ### Recommended Terminal — GNOME Terminal
 


### PR DESCRIPTION
## Summary

Adds a `:MdToConfluence` command and `<localleader>cc` keymap that publishes the current markdown buffer directly to its Confluence page via the REST API — no copy-paste required.

## Changes

- `lua/config/confluence.lua` — new module following the `mdpdf.lua` pattern; discovers the git root, locates `scripts/confluence_publish.py`, checks env vars, and runs the publish script as an async job with `vim.notify` feedback
- `after/ftplugin/markdown.lua` — registers `setup()` and `<localleader>cc` keymap for markdown buffers
- `docs/guides/confluence.md` — full setup guide: prerequisites, API token generation, shell configuration, page map format, usage, diagram rendering, and troubleshooting
- `readme.md` — link to the new guide

## Authentication

Credentials are **never stored in any file**. Set two env vars in your shell profile:

```bash
export CONFLUENCE_EMAIL="you@example.com"
export CONFLUENCE_API_TOKEN="your-token"
```

See [docs/guides/confluence.md](docs/guides/confluence.md) for full setup instructions.

## Dependencies

| Tool | Purpose |
|---|---|
| `pandoc` | Markdown → Confluence storage format |
| `python3` | Runs the publish script |
| PlantUML server *(optional)* | Renders diagrams to inline PNG |

The publish script (`scripts/confluence_publish.py`) lives in the drive-api repo and is discovered automatically from the git root of the open file.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>