### PR TITLE
feat: add Copilot CLI, OpenSpec workflow, and Serena MCP server

### DIFF
--- a/.github/prompts/opsx-apply.prompt.md
+++ b/.github/prompts/opsx-apply.prompt.md
@@ -1,0 +1,149 @@
+---
+description: Implement tasks from an OpenSpec change (Experimental)
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - Context file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read the files listed in `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.github/prompts/opsx-archive.prompt.md
+++ b/.github/prompts/opsx-archive.prompt.md
@@ -1,0 +1,154 @@
+---
+description: Archive a completed change in the experimental workflow
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** openspec/changes/archive/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.github/prompts/opsx-explore.prompt.md
+++ b/.github/prompts/opsx-explore.prompt.md
@@ -1,0 +1,170 @@
+---
+description: Enter explore mode - think through ideas, investigate problems, clarify requirements
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.github/prompts/opsx-propose.prompt.md
+++ b/.github/prompts/opsx-propose.prompt.md
@@ -1,0 +1,103 @@
+---
+description: Propose a new change - create it and generate all artifacts in one step
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.github/skills/openspec-apply-change/SKILL.md
+++ b/.github/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - Context file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read the files listed in `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.github/skills/openspec-archive-change/SKILL.md
+++ b/.github/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.github/skills/openspec-explore/SKILL.md
+++ b/.github/skills/openspec-explore/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│      ┌────────┐         ┌────────┐      │
+│      │ State  │────────▶│ State  │      │
+│      │   A    │         │   B    │      │
+│      └────────┘         └────────┘      │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+    | Insight Type               | Where to Capture               |
+    |----------------------------|--------------------------------|
+    | New requirement discovered | `specs/<capability>/spec.md` |
+    | Requirement changed        | `specs/<capability>/spec.md` |
+    | Design decision made       | `design.md`                  |
+    | Scope changed              | `proposal.md`                |
+    | New work identified        | `tasks.md`                   |
+    | Assumption invalidated     | Relevant artifact              |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │          CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.github/skills/openspec-propose/SKILL.md
+++ b/.github/skills/openspec-propose/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.3.0"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/docs/cheatsheets/ai-tools.md
+++ b/docs/cheatsheets/ai-tools.md
@@ -1,0 +1,54 @@
+# AI Tools Cheat Sheet
+
+Covers in-editor keymaps for **GitHub Copilot CLI** (`gh copilot`) and the **OpenSpec** workflow tool.
+
+**Leader** = `Space`
+
+---
+
+## GitHub Copilot CLI
+
+These commands send the current visual selection (or whole buffer when no selection is active) to the `gh copilot` CLI and display the response in a floating window.
+
+| Keys | Mode | Action |
+|---|---|---|
+| `<leader>gcs` | Normal / Visual | Send to `gh copilot suggest` |
+| `<leader>gce` | Normal / Visual | Send to `gh copilot explain` |
+
+### Commands
+
+| Command | Description |
+|---|---|
+| `:CopilotSuggest` | Send buffer/selection to `gh copilot suggest` |
+| `:CopilotExplain` | Send buffer/selection to `gh copilot explain` |
+
+### Floating window controls
+
+| Key | Action |
+|---|---|
+| `q` | Close result window |
+| `<Esc>` | Close result window |
+
+---
+
+## OpenSpec
+
+Drive the OpenSpec change workflow from within Neovim.  Output is shown in a bottom split (close with `q` or `<Esc>`).
+
+| Keys | Mode | Action |
+|---|---|---|
+| `<leader>osn` | Normal | Create a new change (`OpenspecNew`) |
+| `<leader>oss` | Normal | Show status (`OpenspecStatus`) |
+| `<leader>osl` | Normal | List all changes (`OpenspecList`) |
+
+### Commands
+
+| Command | Description |
+|---|---|
+| `:OpenspecNew [name]` | Prompt for a change name (or use argument) and create it |
+| `:OpenspecStatus [name]` | Show status for all changes, or a specific `[name]` |
+| `:OpenspecList` | List all changes in the repo |
+
+---
+
+→ [Full guide](../guides/ai-tools.md) · [Back to index](index.md)

--- a/docs/cheatsheets/index.md
+++ b/docs/cheatsheets/index.md
@@ -8,12 +8,14 @@
 |---|---|
 | Auto-Completion (nvim-cmp) | [completion.md](completion.md) |
 | Comments (vim-commentary) | [comments.md](comments.md) |
+| C# / .NET (Roslyn + iron.nvim) | [dotnet.md](dotnet.md) |
 | F# REPL (iron.nvim) | [fsharp.md](fsharp.md) |
 | File Tree (nvim-tree) | [file-tree.md](file-tree.md) |
 | Formatting (conform.nvim) | [formatting.md](formatting.md) |
 | Fuzzy Finder (fzf-lua) | [fzf.md](fzf.md) |
 | Git (vim-fugitive + gitsigns) | [git.md](git.md) |
 | GitHub Copilot | [copilot.md](copilot.md) |
+| GitHub Copilot CLI + OpenSpec | [ai-tools.md](ai-tools.md) |
 | Haskell (haskell-tools) | [haskell.md](haskell.md) |
 | HTML Live Preview (Bracey) | [html.md](html.md) |
 | Lisp / Clojure / Scheme (Conjure + vim-sexp) | [lisp.md](lisp.md) |
@@ -117,8 +119,22 @@
 |---|---|---|
 | `Ctrl-j` | Insert | Accept full inline suggestion |
 | `Alt-f` | Insert | Accept next word of suggestion |
+| `<leader>gcs` | Normal / Visual | Copilot CLI: suggest (floating window) |
+| `<leader>gce` | Normal / Visual | Copilot CLI: explain (floating window) |
 
-→ [Full reference](copilot.md)
+→ [Full reference](copilot.md) · [AI Tools guide](ai-tools.md)
+
+---
+
+### OpenSpec
+
+| Keys | Mode | Action |
+|---|---|---|
+| `<leader>osn` | Normal | Create a new OpenSpec change |
+| `<leader>oss` | Normal | Show OpenSpec status |
+| `<leader>osl` | Normal | List all OpenSpec changes |
+
+→ [Full reference](ai-tools.md)
 
 ---
 

--- a/docs/guides/ai-tools.md
+++ b/docs/guides/ai-tools.md
@@ -1,0 +1,119 @@
+# AI Tools Guide
+
+This guide covers three AI / workflow tools that are integrated directly into Neovim:
+
+| Tool | What it does |
+|---|---|
+| **GitHub Copilot CLI** | Ask Copilot to suggest or explain shell commands without leaving the editor |
+| **OpenSpec** | Drive the in-repo OpenSpec change workflow from Neovim keymaps |
+| **Serena MCP server** | Provides symbol-aware code intelligence to GitHub Copilot chat and completions |
+
+---
+
+## GitHub Copilot CLI
+
+### Prerequisites
+
+1. Install [GitHub CLI](https://cli.github.com/):
+   ```sh
+   # Debian / Ubuntu
+   sudo apt install gh
+   # macOS
+   brew install gh
+   ```
+2. Authenticate:
+   ```sh
+   gh auth login
+   ```
+3. Install the Copilot extension:
+   ```sh
+   gh extension install github/gh-copilot
+   ```
+
+### Usage
+
+Select code in visual mode (or stay in normal mode to use the whole buffer), then:
+
+| Keys | Action |
+|---|---|
+| `<leader>gcs` | Ask Copilot to **suggest** a shell command based on context |
+| `<leader>gce` | Ask Copilot to **explain** the selected code or command |
+
+The response appears in a floating window.  Press `q` or `<Esc>` to close it.
+
+You can also run the commands directly:
+- `:CopilotSuggest` — suggest
+- `:CopilotExplain` — explain
+
+### How it works
+
+`lua/config/copilot_cli.lua` uses `vim.system()` to call `gh copilot <subcommand>` asynchronously with the buffer text piped as stdin.  The result is rendered in a scratch buffer inside a `nvim_open_win` floating window.
+
+---
+
+## OpenSpec
+
+OpenSpec is the change-management workflow tool used in this repo (see `openspec/` directory).
+
+### Prerequisites
+
+`openspec` must be on your `$PATH`.  Install it following the project's own README, or check `openspec --help` to confirm it's available.
+
+### Usage
+
+| Keys | Command | Action |
+|---|---|---|
+| `<leader>osn` | `:OpenspecNew` | Prompt for a change name and create it |
+| `<leader>oss` | `:OpenspecStatus` | Show overall change status |
+| `<leader>osl` | `:OpenspecList` | List all changes |
+
+**Scoped status:** pass a change name to `:OpenspecStatus` to see only that change:
+```
+:OpenspecStatus add-copilot-openspec-serena
+```
+
+Output is shown in a read-only bottom split (15 lines tall).  Press `q` or `<Esc>` to close it.
+
+### How it works
+
+`lua/config/openspec.lua` uses synchronous `vim.fn.system()` (appropriate because `openspec` commands complete in well under a second) and opens a scratch buffer in a `botright split`.
+
+---
+
+## Serena MCP Server
+
+[Serena](https://github.com/oramasearch/serena) is a symbol-aware code-intelligence MCP (Model Context Protocol) server.  When running, it allows GitHub Copilot to perform semantic operations — go-to-definition, find-references, workspace symbol search — that it cannot do from text alone.
+
+### Prerequisites
+
+Node.js 18+ is required.  Install Serena globally to avoid `npx` startup latency on every request:
+
+```sh
+npm install -g @oramasearch/serena
+```
+
+Or rely on on-demand `npx` (slower first call, no install needed):
+
+```sh
+# No install needed; npx downloads on first use
+```
+
+### Configuration
+
+Serena is declared in `lua/plugins/copilot.lua` via `vim.g.copilot_mcp_servers`.  No extra setup is needed — it is auto-discovered by `copilot.vim` at startup.
+
+The config prefers the global `serena` binary when found on `$PATH`; otherwise it falls back to `npx -y @oramasearch/serena`.
+
+### Verifying
+
+To confirm the MCP server is configured, run inside Neovim:
+
+```vim
+:lua print(vim.inspect(vim.g.copilot_mcp_servers))
+```
+
+You should see a table with a `serena` key containing `type = "stdio"` and the launch command.
+
+---
+
+→ [Keybinding cheatsheet](../cheatsheets/ai-tools.md)

--- a/init.lua
+++ b/init.lua
@@ -1,3 +1,6 @@
 require('options') -- loads options.lua
 require('loader')  -- loads the loader/init.lua (lazy)
 require('keymaps') -- loads keymaps.lua
+
+require('config.copilot_cli').setup()
+require('config.openspec').setup()

--- a/lua/config/copilot_cli.lua
+++ b/lua/config/copilot_cli.lua
@@ -1,0 +1,151 @@
+-- lua/config/copilot_cli.lua
+--
+-- In-editor integration for the GitHub Copilot CLI (`gh copilot`).
+--
+-- Commands registered by M.setup():
+--   :CopilotSuggest   Send the current visual selection (or whole buffer) to
+--                     `gh copilot suggest` and show the response in a floating
+--                     scratch window.
+--   :CopilotExplain   Send the current visual selection (or whole buffer) to
+--                     `gh copilot explain` and show the explanation in a
+--                     floating scratch window.
+--
+-- Keymaps (set in lua/keymaps.lua):
+--   <leader>gcs  — CopilotSuggest (normal + visual)
+--   <leader>gce  — CopilotExplain (normal + visual)
+--
+-- Requires:
+--   gh   — GitHub CLI with the `copilot` extension installed
+
+local M = {}
+
+--- Extract text from the last visual selection, or the whole buffer when
+--- there is no selection to use.
+--
+-- Uses mark `'<` / `'>` which Neovim updates every time you leave Visual
+-- mode, so this works correctly when a command is invoked with `:'<,'>`.
+--
+---@return string  Multi-line text ready to pass to the CLI.
+local function get_context_text()
+  local mode = vim.fn.mode()
+  -- When called from a visual-range command the mode is already "n", but the
+  -- '<,'> marks are still valid.  We distinguish by whether the command was
+  -- invoked with a range (args.range > 0) — handled at call-site by the
+  -- callers below.  Here we just read whatever the marks say if they exist.
+  local start_pos = vim.fn.getpos("'<")
+  local end_pos   = vim.fn.getpos("'>")
+
+  local buf = vim.api.nvim_get_current_buf()
+  local line_count = vim.api.nvim_buf_line_count(buf)
+
+  local sl = start_pos[2]
+  local el = end_pos[2]
+
+  -- Marks are valid when both are > 0 and within the buffer.
+  local has_selection = sl > 0 and el > 0 and sl <= line_count and el <= line_count
+  if has_selection and sl <= el then
+    local lines = vim.api.nvim_buf_get_lines(buf, sl - 1, el, false)
+    return table.concat(lines, "\n")
+  end
+
+  -- Fall back to the whole buffer.
+  local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+  return table.concat(lines, "\n")
+end
+
+--- Open a floating scratch window and populate it with `lines`.
+--
+---@param title string   Window title shown in the border.
+---@param lines string[] Lines of content to display.
+local function open_float(title, lines)
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+  vim.bo[buf].modifiable = false
+  vim.bo[buf].filetype   = "markdown"
+
+  local width  = math.floor(vim.o.columns * 0.75)
+  local height = math.floor(vim.o.lines * 0.6)
+  local row    = math.floor((vim.o.lines - height) / 2)
+  local col    = math.floor((vim.o.columns - width) / 2)
+
+  vim.api.nvim_open_win(buf, true, {
+    relative = "editor",
+    width    = width,
+    height   = height,
+    row      = row,
+    col      = col,
+    style    = "minimal",
+    border   = "rounded",
+    title    = " " .. title .. " ",
+    title_pos = "center",
+  })
+
+  -- Close with q or <Esc>.
+  local close_opts = { buffer = buf, noremap = true, silent = true }
+  vim.keymap.set("n", "q",     "<cmd>close<CR>", close_opts)
+  vim.keymap.set("n", "<Esc>", "<cmd>close<CR>", close_opts)
+end
+
+--- Run a `gh copilot <subcommand>` with `input` piped via stdin.
+--- Displays the result in a floating window on success; notifies on error.
+--
+---@param subcommand string  "suggest" or "explain"
+---@param input      string  Text to pipe as stdin.
+local function run_copilot(subcommand, input)
+  if vim.fn.executable("gh") ~= 1 then
+    vim.notify(
+      "copilot_cli: `gh` not found on $PATH.\n"
+        .. "Install the GitHub CLI: https://cli.github.com/",
+      vim.log.levels.ERROR
+    )
+    return
+  end
+
+  vim.notify("Copilot CLI: running `gh copilot " .. subcommand .. "` …", vim.log.levels.INFO)
+
+  local stdin_pipe = vim.uv.new_pipe()
+
+  vim.system(
+    { "gh", "copilot", subcommand },
+    {
+      stdin = input,
+    },
+    function(result)
+      vim.schedule(function()
+        if result.code ~= 0 then
+          local err = result.stderr or "(no stderr)"
+          vim.notify(
+            "gh copilot " .. subcommand .. " failed (exit " .. result.code .. "):\n" .. err,
+            vim.log.levels.ERROR
+          )
+          return
+        end
+
+        local output = result.stdout or ""
+        local lines  = vim.split(output, "\n", { plain = true })
+        -- Strip trailing blank lines.
+        while #lines > 0 and lines[#lines] == "" do
+          table.remove(lines)
+        end
+
+        local title = "gh copilot " .. subcommand
+        open_float(title, lines)
+      end)
+    end
+  )
+end
+
+--- Register :CopilotSuggest and :CopilotExplain commands.
+function M.setup()
+  vim.api.nvim_create_user_command("CopilotSuggest", function(args)
+    local text = get_context_text()
+    run_copilot("suggest", text)
+  end, { range = true, desc = "Send selection/buffer to `gh copilot suggest`" })
+
+  vim.api.nvim_create_user_command("CopilotExplain", function(args)
+    local text = get_context_text()
+    run_copilot("explain", text)
+  end, { range = true, desc = "Send selection/buffer to `gh copilot explain`" })
+end
+
+return M

--- a/lua/config/copilot_cli.lua
+++ b/lua/config/copilot_cli.lua
@@ -19,31 +19,45 @@
 
 local M = {}
 
---- Extract text from the last visual selection, or the whole buffer when
---- there is no selection to use.
+--- Extract text from an explicit command range, the active visual selection,
+--- or the whole buffer when neither applies.
 --
--- Uses mark `'<` / `'>` which Neovim updates every time you leave Visual
--- mode, so this works correctly when a command is invoked with `:'<,'>`.
+-- `'<` / `'>` marks persist after leaving Visual mode, so they must not be
+-- treated as a real selection unless the command was invoked with a range or
+-- we are still currently in Visual mode.
 --
+---@param args? { range?: integer, line1?: integer, line2?: integer }
 ---@return string  Multi-line text ready to pass to the CLI.
-local function get_context_text()
-  local mode = vim.fn.mode()
-  -- When called from a visual-range command the mode is already "n", but the
-  -- '<,'> marks are still valid.  We distinguish by whether the command was
-  -- invoked with a range (args.range > 0) — handled at call-site by the
-  -- callers below.  Here we just read whatever the marks say if they exist.
-  local start_pos = vim.fn.getpos("'<")
-  local end_pos   = vim.fn.getpos("'>")
-
+local function get_context_text(args)
   local buf = vim.api.nvim_get_current_buf()
   local line_count = vim.api.nvim_buf_line_count(buf)
 
-  local sl = start_pos[2]
-  local el = end_pos[2]
+  local sl, el
 
-  -- Marks are valid when both are > 0 and within the buffer.
-  local has_selection = sl > 0 and el > 0 and sl <= line_count and el <= line_count
-  if has_selection and sl <= el then
+  if args and args.range and args.range > 0 then
+    sl = args.line1
+    el = args.line2
+  else
+    local mode = vim.fn.mode()
+    local is_visual_mode = mode == "v" or mode == "V" or mode == "\22"
+
+    if is_visual_mode then
+      local start_pos = vim.fn.getpos("'<")
+      local end_pos   = vim.fn.getpos("'>")
+      sl = start_pos[2]
+      el = end_pos[2]
+    end
+  end
+
+  local has_selection = sl ~= nil
+    and el ~= nil
+    and sl > 0
+    and el > 0
+    and sl <= el
+    and sl <= line_count
+    and el <= line_count
+
+  if has_selection then
     local lines = vim.api.nvim_buf_get_lines(buf, sl - 1, el, false)
     return table.concat(lines, "\n")
   end
@@ -103,8 +117,6 @@ local function run_copilot(subcommand, input)
 
   vim.notify("Copilot CLI: running `gh copilot " .. subcommand .. "` …", vim.log.levels.INFO)
 
-  local stdin_pipe = vim.uv.new_pipe()
-
   vim.system(
     { "gh", "copilot", subcommand },
     {
@@ -138,12 +150,12 @@ end
 --- Register :CopilotSuggest and :CopilotExplain commands.
 function M.setup()
   vim.api.nvim_create_user_command("CopilotSuggest", function(args)
-    local text = get_context_text()
+    local text = get_context_text(args)
     run_copilot("suggest", text)
   end, { range = true, desc = "Send selection/buffer to `gh copilot suggest`" })
 
   vim.api.nvim_create_user_command("CopilotExplain", function(args)
-    local text = get_context_text()
+    local text = get_context_text(args)
     run_copilot("explain", text)
   end, { range = true, desc = "Send selection/buffer to `gh copilot explain`" })
 end

--- a/lua/config/openspec.lua
+++ b/lua/config/openspec.lua
@@ -1,0 +1,99 @@
+-- lua/config/openspec.lua
+--
+-- In-editor integration for the OpenSpec workflow CLI (`openspec`).
+--
+-- Commands registered by M.setup():
+--   :OpenspecNew [name]    Prompt for a change name (or use the supplied
+--                          argument) and run `openspec new change "<name>"`.
+--                          Output is shown in a bottom split scratch buffer.
+--   :OpenspecStatus [name] Run `openspec status` (or `openspec status
+--                          --change "<name>"` when a name is given) and show
+--                          the result in a bottom split.
+--   :OpenspecList          Run `openspec list` and show all changes in a
+--                          bottom split.
+--
+-- Keymaps (set in lua/keymaps.lua):
+--   <leader>osn  — OpenspecNew
+--   <leader>oss  — OpenspecStatus
+--   <leader>osl  — OpenspecList
+
+local M = {}
+
+--- Open a read-only scratch buffer in a bottom split containing `lines`.
+--
+---@param title string   Label shown in the first line of the buffer.
+---@param lines string[] Output lines to display.
+local function open_split(title, lines)
+  vim.cmd("botright split")
+  vim.cmd("resize 15")
+
+  local buf = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_set_current_buf(buf)
+
+  local content = { "── " .. title .. " ──", "" }
+  vim.list_extend(content, lines)
+
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, content)
+  vim.bo[buf].modifiable = false
+  vim.bo[buf].buftype    = "nofile"
+  vim.bo[buf].buflisted  = false
+
+  -- Close with q or <Esc>.
+  local close_opts = { buffer = buf, noremap = true, silent = true }
+  vim.keymap.set("n", "q",     "<cmd>close<CR>", close_opts)
+  vim.keymap.set("n", "<Esc>", "<cmd>close<CR>", close_opts)
+end
+
+--- Run an openspec command synchronously and display output in a split.
+--
+---@param cmd   string[]  Full argv list passed to vim.fn.system().
+---@param title string    Label for the split header.
+local function run_and_show(cmd, title)
+  local output = vim.fn.system(cmd)
+  -- Strip ANSI escape sequences for clean display.
+  output = output:gsub("\27%[[%d;]*m", "")
+  local lines = vim.split(output, "\n", { plain = true })
+  -- Trim trailing blank lines.
+  while #lines > 0 and lines[#lines] == "" do
+    table.remove(lines)
+  end
+  open_split(title, lines)
+end
+
+--- Register :OpenspecNew, :OpenspecStatus, and :OpenspecList commands.
+function M.setup()
+  -- :OpenspecNew [name]
+  vim.api.nvim_create_user_command("OpenspecNew", function(args)
+    local name = vim.trim(args.args)
+    if name == "" then
+      name = vim.fn.input("Change name (kebab-case): ")
+      name = vim.trim(name)
+    end
+    if name == "" then
+      vim.notify("OpenspecNew: no change name supplied — aborted.", vim.log.levels.WARN)
+      return
+    end
+    run_and_show({ "openspec", "new", "change", name }, "openspec new change " .. name)
+  end, { nargs = "?", desc = "Create a new OpenSpec change" })
+
+  -- :OpenspecStatus [name]
+  vim.api.nvim_create_user_command("OpenspecStatus", function(args)
+    local name = vim.trim(args.args)
+    local cmd, title
+    if name ~= "" then
+      cmd   = { "openspec", "status", "--change", name }
+      title = "openspec status --change " .. name
+    else
+      cmd   = { "openspec", "status" }
+      title = "openspec status"
+    end
+    run_and_show(cmd, title)
+  end, { nargs = "?", desc = "Show OpenSpec change status", complete = "customlist,v:lua.require'config.openspec'._complete_changes" })
+
+  -- :OpenspecList
+  vim.api.nvim_create_user_command("OpenspecList", function(_)
+    run_and_show({ "openspec", "list" }, "openspec list")
+  end, { desc = "List all OpenSpec changes" })
+end
+
+return M

--- a/lua/config/openspec.lua
+++ b/lua/config/openspec.lua
@@ -50,12 +50,20 @@ end
 ---@param title string    Label for the split header.
 local function run_and_show(cmd, title)
   local output = vim.fn.system(cmd)
+  local exit_code = vim.v.shell_error
   -- Strip ANSI escape sequences for clean display.
   output = output:gsub("\27%[[%d;]*m", "")
   local lines = vim.split(output, "\n", { plain = true })
   -- Trim trailing blank lines.
   while #lines > 0 and lines[#lines] == "" do
     table.remove(lines)
+  end
+  if exit_code ~= 0 then
+    vim.notify(
+      table.concat(cmd, " ") .. " failed (exit " .. exit_code .. ")",
+      vim.log.levels.ERROR
+    )
+    table.insert(lines, 1, "ERROR: exit code " .. exit_code)
   end
   open_split(title, lines)
 end
@@ -88,7 +96,7 @@ function M.setup()
       title = "openspec status"
     end
     run_and_show(cmd, title)
-  end, { nargs = "?", desc = "Show OpenSpec change status", complete = "customlist,v:lua.require'config.openspec'._complete_changes" })
+  end, { nargs = "?", desc = "Show OpenSpec change status" })
 
   -- :OpenspecList
   vim.api.nvim_create_user_command("OpenspecList", function(_)

--- a/lua/keymaps.lua
+++ b/lua/keymaps.lua
@@ -83,3 +83,17 @@ vim.api.nvim_set_keymap("i", "<C-J>", 'copilot#Accept("<CR>")', { silent = true,
 -- <M-f> follows the readline/Emacs "Alt-f = forward word" convention — same semantic intent.
 vim.api.nvim_set_keymap("i", "<M-f>", 'copilot#AcceptWord()', { silent = true, expr = true })
 vim.api.nvim_set_keymap("n", "<leader>c", "<C-w> h", {noremap = true, silent = true})
+
+-- Copilot CLI
+vim.keymap.set({ "n", "v" }, "<leader>gcs", "<cmd>CopilotSuggest<CR>",
+  { noremap = true, silent = true, desc = "Copilot CLI: suggest" })
+vim.keymap.set({ "n", "v" }, "<leader>gce", "<cmd>CopilotExplain<CR>",
+  { noremap = true, silent = true, desc = "Copilot CLI: explain" })
+
+-- OpenSpec
+vim.keymap.set("n", "<leader>osn", "<cmd>OpenspecNew<CR>",
+  { noremap = true, silent = true, desc = "OpenSpec: new change" })
+vim.keymap.set("n", "<leader>oss", "<cmd>OpenspecStatus<CR>",
+  { noremap = true, silent = true, desc = "OpenSpec: status" })
+vim.keymap.set("n", "<leader>osl", "<cmd>OpenspecList<CR>",
+  { noremap = true, silent = true, desc = "OpenSpec: list changes" })

--- a/lua/plugins/copilot.lua
+++ b/lua/plugins/copilot.lua
@@ -7,6 +7,24 @@ return {
       -- vim.g.copilot_model = "gpt-4.1"
       vim.g.copilot_model = "claude-sonnet-4-5"
       -- vim.g.copilot_model = "claude-opus-4-5"
+
+      -- Serena MCP server — symbol-aware code intelligence for Copilot.
+      -- Prefer a globally installed binary; fall back to npx on-demand.
+      local serena_cmd
+      if vim.fn.executable("serena") == 1 then
+        serena_cmd = { "serena" }
+      else
+        serena_cmd = { "npx", "-y", "@oramasearch/serena" }
+      end
+
+      vim.g.copilot_mcp_servers = {
+        serena = {
+          type    = "stdio",
+          command = serena_cmd[1],
+          args    = vim.list_slice(serena_cmd, 2),
+          cwd     = vim.fn.getcwd(),
+        },
+      }
     end,
   },
 }

--- a/openspec/changes/add-jira-workflow/.openspec.yaml
+++ b/openspec/changes/add-jira-workflow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-14

--- a/openspec/changes/add-jira-workflow/design.md
+++ b/openspec/changes/add-jira-workflow/design.md
@@ -1,0 +1,44 @@
+## Context
+
+The config already has a mature Confluence integration (`lua/config/confluence.lua`) using the same Atlassian REST API, the same `curl`-based approach, and the same environment-variable auth pattern (`CONFLUENCE_EMAIL` / `CONFLUENCE_API_TOKEN`). Jira and Confluence are both Atlassian products sharing the same auth model (`JIRA_EMAIL` / `JIRA_API_TOKEN`). The new `lua/config/jira.lua` module mirrors the confluence module's architecture: pure Lua, async `vim.system()` calls, localleader keymaps in the markdown ftplugin, and a project-map file for resolving the target project key.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `:JiraCreateIssue` and `:JiraCreateStory` commands backed by `lua/config/jira.lua`
+- Add `,ji` and `,js` localleader keymaps in `after/ftplugin/markdown.lua`
+- Add `docs/jira-project-map.md` for mapping files/directories to Jira project keys
+- Add `docs/guides/jira.md` with prerequisites and usage instructions
+
+**Non-Goals:**
+- Viewing, searching, or transitioning existing Jira issues
+- A full Jira browser TUI (a separate change)
+- Jira Server (on-premise) support — Jira Cloud REST API v3 only
+- Attachments or custom fields beyond summary, description, and issue type
+
+## Decisions
+
+### Mirror confluence module architecture
+`lua/config/jira.lua` follows the same pattern as `lua/config/confluence.lua`: `M.setup()` registers commands, public functions run async `vim.system()` curl calls, credentials come from env vars. This minimises cognitive overhead and keeps the codebase consistent.
+
+### Use Jira Cloud REST API v3 directly via curl
+No Lua library for Jira exists in this ecosystem. `curl` is already required for Confluence and is available. Using it directly avoids adding new dependencies.
+
+### Separate project-map file (docs/jira-project-map.md)
+A separate map file (analogous to `confluence-page-map.md`) maps local directory paths to Jira project keys. This keeps Jira config decoupled from Confluence config and lets different directories target different Jira projects.
+
+### Issue type distinguished by command, not a prompt
+`:JiraCreateIssue` uses issue type `"Bug"` or `"Task"` and `:JiraCreateStory` uses `"Story"`. Keeping them as separate commands avoids an extra prompt and matches how users think about the difference.
+
+### Summary from a prompt; description from buffer selection or prompt
+When invoked with a visual selection, the selected text becomes the description. Otherwise, a short `vim.ui.input()` prompt collects summary; a second prompt collects description. This keeps the workflow fast for common cases.
+
+## Risks / Trade-offs
+
+- [Risk] `JIRA_EMAIL` / `JIRA_API_TOKEN` not set → command aborts with clear error; no crash. Mitigation: document in `docs/guides/jira.md`.
+- [Risk] Jira project key not in project map → command aborts with error. Mitigation: same pattern as page-map error in Confluence.
+- [Trade-off] Issue type for `:JiraCreateIssue` defaults to `"Task"` — some teams use `"Bug"`. Mitigation: can be extended in a follow-up change.
+
+## Open Questions
+
+- Should the issue summary default to the first line of a visual selection or always be prompted? (Current decision: always prompt for summary; use selection for description only.)

--- a/openspec/changes/add-jira-workflow/proposal.md
+++ b/openspec/changes/add-jira-workflow/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Engineers frequently need to create Jira issues and stories while working in Neovim — writing specs, design docs, or markdown notes. Switching to a browser to file tickets interrupts flow. Adding a Jira workflow following the same pattern as the Confluence integration (pure-Lua, REST API, `curl`, localleader keymaps in the markdown ftplugin) allows issues and stories to be created without leaving the editor.
+
+## What Changes
+
+- Add `lua/config/jira.lua` — pure-Lua module for creating Jira issues and stories via the Jira Cloud REST API v3
+- Add `docs/jira-project-map.md` — maps local directories/files to Jira project keys (analogous to `confluence-page-map.md`)
+- Add `docs/guides/jira.md` — setup and usage guide
+- Register localleader keymaps in `after/ftplugin/markdown.lua`:
+  - `,ji` — create a Jira issue from the current buffer or visual selection
+  - `,js` — create a Jira story from the current buffer or visual selection
+- No changes to the Confluence workflow
+
+## Capabilities
+
+### New Capabilities
+
+- `jira-create-issue`: Create a Jira Bug or Task issue from Neovim, with summary and description populated from the buffer or a prompt
+- `jira-create-story`: Create a Jira Story issue type from Neovim, following the same flow as issue creation
+- `jira-project-map`: Resolution of Jira project key from the current file path via `docs/jira-project-map.md`
+- `jira-auth`: Authentication via `JIRA_EMAIL` and `JIRA_API_TOKEN` environment variables, mirroring the Confluence auth pattern
+
+### Modified Capabilities
+
+<!-- No existing specs require changes -->
+
+## Impact
+
+- New files: `lua/config/jira.lua`, `docs/guides/jira.md`
+- Modified: `after/ftplugin/markdown.lua` (add jira keymaps), `readme.md` (document new commands)
+- External prerequisites: `JIRA_EMAIL`, `JIRA_API_TOKEN` env vars; `curl` (already required for Confluence)
+- No breaking changes; additive only

--- a/openspec/changes/add-jira-workflow/specs/jira-auth/spec.md
+++ b/openspec/changes/add-jira-workflow/specs/jira-auth/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Jira commands authenticate via JIRA_EMAIL and JIRA_API_TOKEN
+The system SHALL read `JIRA_EMAIL` and `JIRA_API_TOKEN` from environment variables for all Jira REST API calls. Both variables MUST be set; if either is missing the command SHALL abort with a clear error message without making any network request.
+
+#### Scenario: Valid credentials present
+- **WHEN** both `JIRA_EMAIL` and `JIRA_API_TOKEN` are set in the environment
+- **THEN** they are passed as HTTP Basic auth (`email:token` base64-encoded) in the `Authorization` header
+
+#### Scenario: Missing credentials
+- **WHEN** either `JIRA_EMAIL` or `JIRA_API_TOKEN` is unset and a Jira command is run
+- **THEN** an error notification `"JIRA_EMAIL and JIRA_API_TOKEN must be set"` is shown and no network request is made
+
+### Requirement: Credentials are never written to any file
+The system SHALL use credentials only in memory (passed as curl arguments) and SHALL NOT write them to any file, log, or buffer.
+
+#### Scenario: Credentials not persisted
+- **WHEN** a Jira command executes
+- **THEN** no file in the repository or on disk contains the credential values

--- a/openspec/changes/add-jira-workflow/specs/jira-create-issue/spec.md
+++ b/openspec/changes/add-jira-workflow/specs/jira-create-issue/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Create a Jira issue (Task) from Neovim
+The system SHALL provide a `:JiraCreateIssue` command and a `,ji` keymap that prompts the user for a summary and optional description, then creates a Jira `Task` issue in the project mapped to the current file via `docs/jira-project-map.md`, using the Jira Cloud REST API v3.
+
+#### Scenario: Successful issue creation
+- **WHEN** the user runs `,ji` or `:JiraCreateIssue`, enters a summary and description, and valid credentials and a project map entry exist
+- **THEN** a Jira Task issue is created and a success notification shows the new issue key and URL
+
+#### Scenario: Visual selection used as description
+- **WHEN** the user selects text in visual mode before running `,ji`
+- **THEN** the selected text is pre-populated as the issue description and only a summary prompt is shown
+
+#### Scenario: Current file not in project map
+- **WHEN** no entry for the current file's path exists in `docs/jira-project-map.md`
+- **THEN** an error notification is shown and no API call is made
+
+#### Scenario: Creation is non-blocking
+- **WHEN** `,ji` is triggered and the API call is in flight
+- **THEN** the Neovim UI remains interactive

--- a/openspec/changes/add-jira-workflow/specs/jira-create-story/spec.md
+++ b/openspec/changes/add-jira-workflow/specs/jira-create-story/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Create a Jira story from Neovim
+The system SHALL provide a `:JiraCreateStory` command and a `,js` keymap that prompts the user for a summary and optional description, then creates a Jira `Story` issue in the project mapped to the current file, using the Jira Cloud REST API v3.
+
+#### Scenario: Successful story creation
+- **WHEN** the user runs `,js` or `:JiraCreateStory`, enters a summary, and valid credentials and a project map entry exist
+- **THEN** a Jira Story issue is created and a success notification shows the new issue key and URL
+
+#### Scenario: Visual selection used as description
+- **WHEN** the user selects text in visual mode before running `,js`
+- **THEN** the selected text is pre-populated as the story description and only a summary prompt is shown
+
+#### Scenario: Story and Issue creation share the same flow
+- **WHEN** both `:JiraCreateIssue` and `:JiraCreateStory` are used
+- **THEN** the only difference is the `issuetype.name` field sent to the API (`"Task"` vs `"Story"`)
+
+#### Scenario: Current file not in project map
+- **WHEN** no entry for the current file's path exists in `docs/jira-project-map.md`
+- **THEN** an error notification is shown and no API call is made

--- a/openspec/changes/add-jira-workflow/specs/jira-project-map/spec.md
+++ b/openspec/changes/add-jira-workflow/specs/jira-project-map/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Project map resolves Jira project key from current file path
+The system SHALL read `docs/jira-project-map.md` at the git root to determine the Jira project key for the current file. Each row in the table SHALL map a local path prefix (directory or file, relative to the git root) to a Jira project key (e.g., `DRIVER`, `ROAD`).
+
+#### Scenario: File path matches project map entry
+- **WHEN** the current file's path starts with a prefix listed in `docs/jira-project-map.md`
+- **THEN** the corresponding project key is returned and used for issue creation
+
+#### Scenario: Most-specific prefix wins
+- **WHEN** multiple entries in the project map could match the current file path
+- **THEN** the longest matching prefix is used
+
+#### Scenario: File not matched by any prefix
+- **WHEN** no entry in `docs/jira-project-map.md` matches the current file's path
+- **THEN** an error notification is shown and no API call is made
+
+### Requirement: Project map is located relative to the git root
+The system SHALL find `docs/jira-project-map.md` relative to the git root of the current file, not the Neovim working directory.
+
+#### Scenario: Map found via git root
+- **WHEN** the current file is inside a git repository whose root contains `docs/jira-project-map.md`
+- **THEN** that file is used as the project map
+
+#### Scenario: No git root or no project map
+- **WHEN** the file is outside a git repo, or `docs/jira-project-map.md` does not exist
+- **THEN** an error notification is shown and the command aborts

--- a/openspec/changes/add-jira-workflow/tasks.md
+++ b/openspec/changes/add-jira-workflow/tasks.md
@@ -1,0 +1,33 @@
+## 1. Core Module
+
+- [ ] 1.1 Create `lua/config/jira.lua` with `M.setup()` registering `:JiraCreateIssue` and `:JiraCreateStory` user commands
+- [ ] 1.2 Implement `find_git_root()` helper (or reuse pattern from `confluence.lua`)
+- [ ] 1.3 Implement `find_project_key()` to read `docs/jira-project-map.md` and resolve the Jira project key for the current file using longest-prefix matching
+- [ ] 1.4 Implement `M.create_issue(issue_type)` — validates credentials, resolves project key, prompts for summary, uses visual selection or prompts for description, and POSTs to Jira Cloud REST API v3 `/rest/api/3/issue`
+- [ ] 1.5 Implement async `vim.system()` curl call with Basic auth (`JIRA_EMAIL:JIRA_API_TOKEN`), JSON body, and `Content-Type: application/json` header
+- [ ] 1.6 Parse the JSON response and show a success notification with the new issue key and Jira URL, or an error notification on failure
+
+## 2. Keymaps and Commands
+
+- [ ] 2.1 Add `require("config.jira").setup()` call in `after/ftplugin/markdown.lua`
+- [ ] 2.2 Add `,ji` keymap → `:JiraCreateIssue` in `after/ftplugin/markdown.lua`
+- [ ] 2.3 Add `,js` keymap → `:JiraCreateStory` in `after/ftplugin/markdown.lua`
+- [ ] 2.4 Add visual-mode variants of `,ji` and `,js` so the selection is passed as the description
+
+## 3. Project Map
+
+- [ ] 3.1 Create `docs/jira-project-map.md` with a sample table documenting the format (directory prefix → project key)
+
+## 4. Documentation
+
+- [ ] 4.1 Create `docs/guides/jira.md` covering prerequisites (`JIRA_EMAIL`, `JIRA_API_TOKEN`, `curl`), project map format, and keymap reference
+- [ ] 4.2 Update `readme.md` to list `,ji` and `,js` in the keybindings table and add Jira to the integrations section
+- [ ] 4.3 Update `docs/cheatsheets/index.md` if a Jira cheatsheet entry is warranted
+
+## 5. Validation
+
+- [ ] 5.1 Syntax-check `lua/config/jira.lua` and `after/ftplugin/markdown.lua` with `luac -p`
+- [ ] 5.2 Open a markdown file and confirm `:JiraCreateIssue` prompts for summary and description
+- [ ] 5.3 Confirm a Task issue is created in the correct Jira project and the success notification shows the issue key
+- [ ] 5.4 Repeat with `:JiraCreateStory` and confirm issue type is `"Story"`
+- [ ] 5.5 Confirm that missing `JIRA_EMAIL` or `JIRA_API_TOKEN` aborts with the correct error message

--- a/openspec/changes/add-lua-language-support/.openspec.yaml
+++ b/openspec/changes/add-lua-language-support/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-14

--- a/openspec/changes/add-lua-language-support/proposal.md
+++ b/openspec/changes/add-lua-language-support/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Lua is the primary configuration language for this Neovim setup, yet it currently has no LSP, no formatter, and no filetype-specific editor settings. Adding first-class Lua support improves the experience of editing the config itself and any Lua scripts in the repo.
+
+## What Changes
+
+- Add `lua_ls` (lua-language-server) to `lua/config/lsp.lua` with Neovim-aware workspace library settings
+- Add `stylua` formatter for Lua files in `lua/plugins/conform.lua`
+- Add `after/ftplugin/lua.lua` for per-buffer indent and editor settings
+
+## Capabilities
+
+### New Capabilities
+
+- `lua-lsp`: Configure `lua_ls` with `on_attach` and Neovim runtime library so go-to-definition, hover, rename, and diagnostics work in `.lua` files
+- `lua-formatting`: Register `stylua` as the formatter for `ft=lua` in conform.nvim
+- `lua-ftplugin`: Per-buffer filetype settings for Lua (indent width, `nospell`, etc.)
+
+### Modified Capabilities
+
+<!-- none -->
+
+## Impact
+
+- `lua/config/lsp.lua` — new server setup block
+- `lua/plugins/conform.lua` — new `lua` entry in `formatters_by_ft`
+- `after/ftplugin/lua.lua` — new file
+- `readme.md` and docs — Language Support table updated; no new guide needed (Lua is the config language, not a project language)
+- External dependency: `lua-language-server` binary must be on `$PATH` (installable via system package manager or Mason); `stylua` binary must be on `$PATH`

--- a/openspec/changes/add-lua-support/.openspec.yaml
+++ b/openspec/changes/add-lua-support/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-14

--- a/openspec/changes/add-lua-support/design.md
+++ b/openspec/changes/add-lua-support/design.md
@@ -1,0 +1,35 @@
+## Context
+
+The config currently supports Lua via Treesitter (syntax highlighting + indentation) but has no LSP integration, no formatter, and no filetype-specific editor settings. Lua is the primary language used to write and extend this Neovim configuration. The existing language support pattern — used for F#, Haskell, Common Lisp, and others — consists of an LSP entry in `lua/config/lsp.lua`, a formatter entry in `lua/plugins/conform.lua`, and a filetype plugin at `after/ftplugin/<lang>.lua`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `lua_ls` LSP configuration following the same pattern as all other servers in `lua/config/lsp.lua`
+- Add `stylua` format-on-save via `conform.nvim`, consistent with other filetypes
+- Add `after/ftplugin/lua.lua` with 2-space indent settings matching Neovim's own Lua style
+
+**Non-Goals:**
+- Adding a Lua REPL (no clear lightweight option integrates with the current iron.nvim / Conjure approach for Lua)
+- Adding snippets or a dedicated debugging adapter
+- Configuring `lua_ls` to understand the Neovim runtime API (that requires a more complex `settings` block and is a separate change)
+
+## Decisions
+
+### `lua_ls` as the LSP server
+`lua_ls` (formerly sumneko/lua-language-server) is the only actively maintained, full-featured Lua language server. No viable alternatives exist.
+
+### `stylua` as the formatter
+`stylua` is the de-facto standard Lua formatter (opinionated, fast, zero-config). Alternatives like `luafmt` are unmaintained. `lsp_format = "prefer"` is not viable because `lua_ls` formatting is rarely enabled. Using `{ "stylua" }` directly is the right choice.
+
+### Extend `conform.nvim`'s `ft` guard for lazy loading
+Adding `"lua"` to the `ft` list ensures conform is loaded for Lua files without changing the loader structure.
+
+### No `localleader` keymaps in `after/ftplugin/lua.lua`
+Other filetypes define `<localleader>` REPL and eval keymaps. Since no REPL is being added, the ftplugin only sets indent options. A comment placeholder will indicate where to add keymaps if a REPL is added later.
+
+## Risks / Trade-offs
+
+- [Risk] `lua-language-server` binary not on `$PATH` → LSP silently does nothing; no crash. Mitigation: document the prerequisite in `docs/guides/lua.md`.
+- [Risk] `stylua` not on `$PATH` → conform logs a warning on save. Mitigation: document in the same guide.
+- [Trade-off] No `lua_ls` Neovim API awareness means diagnostics may flag Neovim globals (`vim.*`). Mitigation: acceptable for now; a follow-up change can add `settings.Lua.workspace.library`.

--- a/openspec/changes/add-lua-support/proposal.md
+++ b/openspec/changes/add-lua-support/proposal.md
@@ -1,0 +1,29 @@
+## Why
+
+Lua is the primary configuration language for Neovim, and users who extend this config or develop plugins in Lua have no language-server support, no format-on-save, and no filetype-specific editor settings. Adding first-class Lua support closes this gap for the most common editing language in the repo.
+
+## What Changes
+
+- Add `lua_ls` (lua-language-server) LSP configuration in `lua/config/lsp.lua`
+- Add `stylua` as the formatter for Lua in `lua/plugins/conform.lua`, with format-on-save
+- Add `after/ftplugin/lua.lua` with indent settings (2-space) and localleader keymaps
+
+## Capabilities
+
+### New Capabilities
+
+- `lua-lsp`: Language server support for Lua via `lua_ls`, providing diagnostics, hover docs, go-to-definition, and rename
+- `lua-formatting`: Format-on-save for Lua files using `stylua` via conform.nvim
+- `lua-ftplugin`: Filetype settings for Lua — 2-space indentation and any Lua-specific keymaps
+
+### Modified Capabilities
+
+<!-- No existing specs require changes -->
+
+## Impact
+
+- `lua/config/lsp.lua`: new `lspconfig.lua_ls.setup{}` call
+- `lua/plugins/conform.lua`: add `lua` to `formatters_by_ft` and `ft` list; add `stylua` formatter
+- `after/ftplugin/lua.lua`: new file for filetype-local settings
+- External prerequisite: `lua-language-server` binary must be on `$PATH`; `stylua` binary must be on `$PATH`
+- No breaking changes; additive only

--- a/openspec/changes/add-lua-support/specs/lua-formatting/spec.md
+++ b/openspec/changes/add-lua-support/specs/lua-formatting/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Lua files are formatted with stylua on save
+The config SHALL add `lua` to `conform.nvim`'s `formatters_by_ft` table using `{ "stylua" }` and to the `ft` lazy-load guard, so that Lua buffers are formatted with `stylua` on every save.
+
+#### Scenario: Format on save triggers stylua
+- **WHEN** the user saves a Lua file and `stylua` is on `$PATH`
+- **THEN** `stylua` formats the buffer before write, within the 2000 ms timeout
+
+#### Scenario: Manual format keybinding works for Lua
+- **WHEN** the user presses `<leader>f` in a Lua buffer
+- **THEN** `conform.format({ async = true })` runs `stylua` on the current buffer or visual selection
+
+#### Scenario: Missing stylua does not block save
+- **WHEN** `stylua` is not installed or not on `$PATH`
+- **THEN** the file is saved without formatting and conform logs a warning

--- a/openspec/changes/add-lua-support/specs/lua-ftplugin/spec.md
+++ b/openspec/changes/add-lua-support/specs/lua-ftplugin/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Lua filetype plugin sets 2-space indentation
+The config SHALL provide `after/ftplugin/lua.lua` that sets `shiftwidth=2`, `tabstop=2`, `softtabstop=2`, and `expandtab` for all Lua buffers, matching Neovim's own Lua coding style.
+
+#### Scenario: Indent settings applied on Lua buffer open
+- **WHEN** the user opens any `.lua` file
+- **THEN** `shiftwidth`, `tabstop`, and `softtabstop` are all 2, and `expandtab` is enabled for that buffer
+
+#### Scenario: Settings are buffer-local
+- **WHEN** a Lua buffer is open alongside a buffer of another filetype
+- **THEN** the Lua indent settings do not affect the other buffer's settings

--- a/openspec/changes/add-lua-support/specs/lua-lsp/spec.md
+++ b/openspec/changes/add-lua-support/specs/lua-lsp/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: lua_ls is configured as the Lua LSP server
+The config SHALL register `lua_ls` via `lspconfig.lua_ls.setup{}` using the shared `on_attach` function defined in `lua/config/lsp.lua`, providing diagnostics, hover documentation, go-to-definition, references, rename, and code actions in Lua buffers.
+
+#### Scenario: LSP attaches on Lua buffer open
+- **WHEN** the user opens a `.lua` file and `lua-language-server` is on `$PATH`
+- **THEN** `lua_ls` attaches to the buffer and LSP keymaps (`gd`, `K`, `gr`, `<leader>rn`, `<leader>ca`, `<leader>e`, `[d`, `]d`) are active
+
+#### Scenario: LSP keymaps match other languages
+- **WHEN** `lua_ls` attaches to a Lua buffer
+- **THEN** all keymaps are identical to those registered by the shared `on_attach` function used for `fsautocomplete`, `marksman`, and `cl_lsp`
+
+#### Scenario: Missing binary does not crash
+- **WHEN** `lua-language-server` is not installed or not on `$PATH`
+- **THEN** Neovim starts without error and no LSP attaches to Lua buffers

--- a/openspec/changes/add-lua-support/tasks.md
+++ b/openspec/changes/add-lua-support/tasks.md
@@ -1,0 +1,27 @@
+## 1. LSP Setup
+
+- [ ] 1.1 Add `lspconfig.lua_ls.setup{ on_attach = on_attach }` to `lua/config/lsp.lua`
+- [ ] 1.2 Verify `lua-language-server` is documented as a prerequisite in `docs/guides/lua.md` (create file if it doesn't exist)
+
+## 2. Formatting
+
+- [ ] 2.1 Add `"lua"` to the `ft` list in `lua/plugins/conform.lua` so conform lazy-loads for Lua
+- [ ] 2.2 Add `lua = { "stylua" }` entry to `formatters_by_ft` in `lua/plugins/conform.lua`
+- [ ] 2.3 Document `stylua` as a prerequisite in `docs/guides/lua.md`
+
+## 3. Filetype Plugin
+
+- [ ] 3.1 Create `after/ftplugin/lua.lua` with `shiftwidth=2`, `tabstop=2`, `softtabstop=2`, and `expandtab` set as buffer-local options
+
+## 4. Documentation
+
+- [ ] 4.1 Create `docs/guides/lua.md` covering prerequisites (`lua-language-server`, `stylua`), available features (LSP keymaps, format-on-save), and indent settings
+- [ ] 4.2 Update `readme.md` Language Support table to reflect full Lua support (LSP + formatting)
+- [ ] 4.3 Update `docs/cheatsheets/index.md` if a Lua cheatsheet is added
+
+## 5. Validation
+
+- [ ] 5.1 Syntax-check all modified Lua files with `luac -p` (or `:luafile %` in Neovim)
+- [ ] 5.2 Open a `.lua` file in Neovim and confirm `lua_ls` attaches (`:LspInfo`)
+- [ ] 5.3 Save a Lua file and confirm `stylua` formats it
+- [ ] 5.4 Open a Lua buffer and confirm `shiftwidth` is 2 (`:set shiftwidth?`)

--- a/openspec/changes/archive/2026-04-14-add-copilot-openspec-serena/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-14-add-copilot-openspec-serena/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-14

--- a/openspec/changes/archive/2026-04-14-add-copilot-openspec-serena/design.md
+++ b/openspec/changes/archive/2026-04-14-add-copilot-openspec-serena/design.md
@@ -1,0 +1,52 @@
+## Context
+
+The config already has `github/copilot.vim` for inline completions. The surrounding tooling — `gh copilot` CLI, the in-repo `openspec` workflow tool, and the Serena MCP server — has no Neovim integration. Each tool lives in the terminal and is completely disconnected from the editor. This change adds lightweight Lua modules and keymaps so developers can drive all three from inside Neovim without switching context.
+
+The config follows the pattern: config logic in `lua/config/`, global keymaps in `lua/keymaps.lua`, filetype keymaps in `after/ftplugin/`, and plugin declarations in `lua/plugins/`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `lua/config/copilot_cli.lua` with `:CopilotSuggest` and `:CopilotExplain` commands that pass the current buffer or visual selection to `gh copilot suggest` / `gh copilot explain` and display the result.
+- Add `lua/config/openspec.lua` with `:OpenspecNew`, `:OpenspecStatus`, and `:OpenspecList` commands, wired to `<leader>os*` keymaps and loaded at startup.
+- Add Serena MCP server configuration inside `lua/plugins/copilot.lua` so `copilot.vim` can discover and route requests to it.
+- Document all new keybindings in `readme.md`, `docs/cheatsheets/index.md`, and a new `docs/cheatsheets/ai-tools.md`.
+
+**Non-Goals:**
+- Building a full TUI for OpenSpec or Copilot CLI.
+- Replacing the existing `copilot.vim` inline completion setup.
+- Auto-starting or managing the Serena process — the user is responsible for running it.
+
+## Decisions
+
+### 1. Copilot CLI: `vim.system()` with floating window output
+
+`vim.system()` (Neovim 0.10+) is already used elsewhere in this config (`lua/config/confluence.lua`). Shell output is collected async and rendered in a scratch buffer inside a floating window using `nvim_open_win`. This keeps it non-blocking and consistent with the rest of the config.
+
+**Alternative considered**: ToggleTerm / vim-floaterm. Rejected — adds another plugin dependency for a simple one-shot command.
+
+### 2. OpenSpec: synchronous `vim.fn.system()` with split output
+
+OpenSpec commands (`new`, `status`, `list`) are fast and non-interactive. Using synchronous `vim.fn.system()` and opening a read-only scratch buffer in a bottom split is simpler than async and is sufficient for sub-second commands.
+
+**Alternative considered**: Async with `vim.system()`. Acceptable but overkill for sub-second CLI calls.
+
+### 3. Serena MCP: `vim.g.copilot_mcp_servers` table in `copilot.lua`
+
+`copilot.vim` reads `vim.g.copilot_mcp_servers` (a Vimscript global) to discover MCP servers. We add Serena there using the `stdio` transport pointing at its `npx` launch command. Config lives in `lua/plugins/copilot.lua` alongside the existing Copilot setup.
+
+**Alternative considered**: A separate `lua/plugins/serena.lua`. Rejected — Serena has no lazy.nvim plugin; it's a pure runtime config entry.
+
+### 4. Keymap namespace
+
+- Copilot CLI: `<leader>gc` prefix (`g`=GitHub, `c`=Copilot): `<leader>gcs` suggest, `<leader>gce` explain.
+- OpenSpec: `<leader>os` prefix: `<leader>osn` new, `<leader>oss` status, `<leader>osl` list.
+
+These do not conflict with any existing keymaps in `lua/keymaps.lua`.
+
+## Risks / Trade-offs
+
+- **`gh copilot` not installed** → Commands fail with a clear error message via `vim.notify`. Mitigation: guard with `vim.fn.executable("gh")` check.
+- **Serena not running** → Copilot silently skips the MCP server; no editor crash. Low risk.
+- **`npx` startup latency for Serena** → First MCP call may be slow if Serena package isn't cached. Mitigation: document `npm install -g @oramasearch/serena` as the preferred setup.
+- **OpenSpec CWD mismatch** → Commands must run from the repo root. Mitigation: always call with `cwd = vim.fn.getcwd()` and surface the path in the output header.

--- a/openspec/changes/archive/2026-04-14-add-copilot-openspec-serena/proposal.md
+++ b/openspec/changes/archive/2026-04-14-add-copilot-openspec-serena/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The Neovim config has strong AI assistance via `copilot.vim` but lacks deep integration with the surrounding developer workflow tools — GitHub Copilot CLI (`gh copilot`), the in-repo OpenSpec workflow, and the Serena MCP code-intelligence server. Adding these three integrations closes the gap between the editor and the tools used to build and manage the config itself.
+
+## What Changes
+
+- **Copilot CLI integration**: Add Neovim commands and keymaps to invoke `gh copilot suggest` and `gh copilot explain` from within the editor, feeding the current buffer or visual selection as context.
+- **OpenSpec integration**: Add Neovim commands and keymaps to run common `openspec` CLI operations (new change, status, list) without leaving the editor; show output in a floating window or split.
+- **Serena MCP server**: Configure Serena as an MCP server in `copilot.vim` to provide symbol-aware code intelligence (go-to-definition, references, workspace search) to GitHub Copilot chat and inline completions.
+
+## Capabilities
+
+### New Capabilities
+
+- `copilot-cli-integration`: In-editor keymaps and commands for `gh copilot suggest` and `gh copilot explain`, operating on the current buffer or visual selection.
+- `openspec-integration`: In-editor commands and keymaps for driving the OpenSpec workflow (create change, view status, list artifacts) from Neovim.
+- `serena-mcp-server`: Configuration of the Serena MCP server so GitHub Copilot can leverage symbol-aware code intelligence across the workspace.
+
+### Modified Capabilities
+
+## Impact
+
+- **New files**: `lua/config/copilot_cli.lua`, `lua/config/openspec.lua`, `lua/config/serena.lua` (MCP config), potentially `after/ftplugin/` entries for filetype-scoped keymaps.
+- **Modified files**: `lua/plugins/copilot.lua` (add MCP server declaration for Serena), `lua/keymaps.lua` (global keymaps for Copilot CLI and OpenSpec), `readme.md`, and relevant docs.
+- **External dependencies**: `gh` CLI with `copilot` extension installed, `openspec` CLI already present, Serena MCP server installed (e.g., via `npx` or global npm).
+- No breaking changes to existing plugin configuration.

--- a/openspec/changes/archive/2026-04-14-add-copilot-openspec-serena/specs/copilot-cli-integration/spec.md
+++ b/openspec/changes/archive/2026-04-14-add-copilot-openspec-serena/specs/copilot-cli-integration/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Suggest command
+The plugin SHALL provide a `:CopilotSuggest` command that passes the current visual selection (or whole buffer when no selection is active) as context to `gh copilot suggest` and displays the response in a floating scratch window.
+
+#### Scenario: Suggest with visual selection
+- **WHEN** the user selects lines in visual mode and runs `:CopilotSuggest`
+- **THEN** the selected text is sent to `gh copilot suggest` and the response is shown in a floating window
+
+#### Scenario: Suggest with no selection
+- **WHEN** the user runs `:CopilotSuggest` with no active visual selection
+- **THEN** the entire buffer content is sent to `gh copilot suggest` and the response is shown in a floating window
+
+#### Scenario: gh CLI not installed
+- **WHEN** `gh` is not found on `$PATH`
+- **THEN** the system SHALL emit a `vim.notify` error and abort without opening a window
+
+### Requirement: Explain command
+The plugin SHALL provide a `:CopilotExplain` command that sends the current visual selection (or whole buffer) to `gh copilot explain` and displays the explanation in a floating scratch window.
+
+#### Scenario: Explain selected code
+- **WHEN** the user selects code and runs `:CopilotExplain`
+- **THEN** the selected text is sent to `gh copilot explain` and the explanation is shown in a floating window
+
+#### Scenario: Explain whole buffer
+- **WHEN** `:CopilotExplain` is run with no selection
+- **THEN** the buffer content is sent and the explanation is shown
+
+### Requirement: Keymap bindings
+The integration SHALL expose `<leader>gcs` for suggest and `<leader>gce` for explain in normal and visual mode via `lua/keymaps.lua`.
+
+#### Scenario: Normal mode suggest keymap
+- **WHEN** the user presses `<leader>gcs` in normal mode
+- **THEN** `:CopilotSuggest` is triggered with the full buffer
+
+#### Scenario: Visual mode explain keymap
+- **WHEN** the user presses `<leader>gce` in visual mode
+- **THEN** `:CopilotExplain` is triggered with the selected lines

--- a/openspec/changes/archive/2026-04-14-add-copilot-openspec-serena/specs/openspec-integration/spec.md
+++ b/openspec/changes/archive/2026-04-14-add-copilot-openspec-serena/specs/openspec-integration/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: New change command
+The integration SHALL provide a `:OpenspecNew` command that prompts for a change name and runs `openspec new change "<name>"`, displaying the result in a bottom split scratch buffer.
+
+#### Scenario: Create new change
+- **WHEN** the user runs `:OpenspecNew` and enters a name
+- **THEN** `openspec new change "<name>"` is executed in the repo root and output is shown in a split
+
+#### Scenario: Empty name rejected
+- **WHEN** the user cancels the input prompt or submits an empty name
+- **THEN** the command SHALL abort with no side effects
+
+### Requirement: Status command
+The integration SHALL provide a `:OpenspecStatus` command that runs `openspec status` (or `openspec status --change "<name>"` when a change name is supplied) and shows the output in a bottom split.
+
+#### Scenario: Global status
+- **WHEN** `:OpenspecStatus` is run with no argument
+- **THEN** `openspec status` output is shown in a split
+
+#### Scenario: Change-scoped status
+- **WHEN** `:OpenspecStatus <name>` is run with a change name argument
+- **THEN** `openspec status --change "<name>"` output is shown in a split
+
+### Requirement: List command
+The integration SHALL provide an `:OpenspecList` command that runs `openspec list` and shows available changes in a split.
+
+#### Scenario: List all changes
+- **WHEN** `:OpenspecList` is run
+- **THEN** `openspec list` output is shown in a read-only split buffer
+
+### Requirement: Keymap bindings
+The integration SHALL expose `<leader>osn` (new), `<leader>oss` (status), `<leader>osl` (list) in normal mode via `lua/keymaps.lua`.
+
+#### Scenario: Status keymap
+- **WHEN** the user presses `<leader>oss`
+- **THEN** `:OpenspecStatus` is triggered
+
+#### Scenario: List keymap
+- **WHEN** the user presses `<leader>osl`
+- **THEN** `:OpenspecList` is triggered

--- a/openspec/changes/archive/2026-04-14-add-copilot-openspec-serena/specs/serena-mcp-server/spec.md
+++ b/openspec/changes/archive/2026-04-14-add-copilot-openspec-serena/specs/serena-mcp-server/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: MCP server declaration
+The config SHALL declare the Serena MCP server in `vim.g.copilot_mcp_servers` inside `lua/plugins/copilot.lua` so that `copilot.vim` can route code-intelligence requests to it.
+
+#### Scenario: Server declared at startup
+- **WHEN** Neovim starts and `copilot.vim` loads
+- **THEN** `vim.g.copilot_mcp_servers` SHALL contain an entry for Serena with `stdio` transport and the correct launch command
+
+#### Scenario: Serena not running
+- **WHEN** Serena is not installed or not reachable
+- **THEN** `copilot.vim` SHALL skip the server gracefully with no editor error
+
+### Requirement: Launch command configuration
+The Serena entry SHALL use `npx -y @oramasearch/serena` as the default launch command, with the workspace root (`vim.fn.getcwd()`) passed as the working directory.
+
+#### Scenario: npx launch
+- **WHEN** Copilot initiates an MCP request to Serena
+- **THEN** the server process SHALL be spawned via `npx -y @oramasearch/serena` in the current workspace root
+
+#### Scenario: Global install override
+- **WHEN** `serena` is found on `$PATH` (global npm install)
+- **THEN** the config SHALL prefer the global binary over `npx` to avoid startup latency
+
+### Requirement: Documentation
+Installation prerequisites (Node.js, `npx` or global serena package) SHALL be documented in `readme.md` and `docs/guides/ai-tools.md`.
+
+#### Scenario: Readme documents prerequisites
+- **WHEN** a user reads the Serena section of `readme.md`
+- **THEN** they SHALL find the install command and a note about the Node.js requirement

--- a/openspec/changes/archive/2026-04-14-add-copilot-openspec-serena/tasks.md
+++ b/openspec/changes/archive/2026-04-14-add-copilot-openspec-serena/tasks.md
@@ -1,0 +1,33 @@
+## 1. Copilot CLI Integration
+
+- [x] 1.1 Create `lua/config/copilot_cli.lua` with `CopilotSuggest` and `CopilotExplain` commands using `vim.system()` and a floating scratch window
+- [x] 1.2 Guard both commands with `vim.fn.executable("gh")` check; emit `vim.notify` error on failure
+- [x] 1.3 Implement visual-selection extraction (yanking to a temp register) so both commands work in normal and visual mode
+- [x] 1.4 Add `require("config.copilot_cli")` call in `init.lua` or via the loader
+- [x] 1.5 Add `<leader>gcs` (suggest) and `<leader>gce` (explain) keymaps in `lua/keymaps.lua`
+
+## 2. OpenSpec Integration
+
+- [x] 2.1 Create `lua/config/openspec.lua` with `OpenspecNew`, `OpenspecStatus`, and `OpenspecList` commands using synchronous `vim.fn.system()` and a bottom split scratch buffer
+- [x] 2.2 Implement `vim.fn.input()` prompt in `OpenspecNew` and guard against empty/cancelled input
+- [x] 2.3 Support optional `<name>` argument in `OpenspecStatus` for change-scoped output
+- [x] 2.4 Add `require("config.openspec")` call in `init.lua` or via the loader
+- [x] 2.5 Add `<leader>osn` (new), `<leader>oss` (status), `<leader>osl` (list) keymaps in `lua/keymaps.lua`
+
+## 3. Serena MCP Server
+
+- [x] 3.1 Add `vim.g.copilot_mcp_servers` declaration in `lua/plugins/copilot.lua` with Serena entry (`stdio`, `npx -y @oramasearch/serena`)
+- [x] 3.2 Add logic to prefer global `serena` binary over `npx` when `vim.fn.executable("serena")` returns true
+
+## 4. Documentation
+
+- [x] 4.1 Update `readme.md` — add Copilot CLI and OpenSpec keymaps to General Keybindings table; add Serena prerequisites callout; update Plugin Overview table
+- [x] 4.2 Update `docs/cheatsheets/index.md` — add rows for new keymaps
+- [x] 4.3 Create `docs/cheatsheets/ai-tools.md` — full cheatsheet for Copilot CLI and OpenSpec keymaps
+- [x] 4.4 Create `docs/guides/ai-tools.md` — guide covering installation prerequisites (`gh copilot`, `openspec`, Serena via npm) and usage walkthrough
+
+## 5. Validation
+
+- [x] 5.1 Syntax-check all new Lua files with `find . -name '*.lua' -print0 | xargs -0 luac -p`
+- [x] 5.2 Smoke-test `:CopilotSuggest`, `:CopilotExplain`, `:OpenspecStatus`, `:OpenspecList` in a running Neovim session
+- [x] 5.3 Verify `vim.g.copilot_mcp_servers` is set at startup with `:lua print(vim.inspect(vim.g.copilot_mcp_servers))`

--- a/openspec/changes/document-confluence-workflow/.openspec.yaml
+++ b/openspec/changes/document-confluence-workflow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-14

--- a/openspec/changes/document-confluence-workflow/design.md
+++ b/openspec/changes/document-confluence-workflow/design.md
@@ -1,0 +1,30 @@
+## Context
+
+The Confluence workflow (`lua/config/confluence.lua`) is a 622-line pure-Lua module that has grown organically to handle publish, pull, comments, conflict detection, page-map resolution, and an optional Lua filter pipeline. It has comprehensive inline comments but no formal specification. This change captures its intended behaviour as a set of verifiable requirements — no code changes.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Produce one spec file per logical capability (6 total) that completely describes the observable behaviour of the existing implementation
+- Each spec serves as: (a) a regression baseline for future changes, (b) a review target for AI-assisted modifications, and (c) onboarding documentation
+
+**Non-Goals:**
+- Changing any code; this is documentation only
+- Specifying internal helper functions (find_git_root, find_page_entry, etc.) — only observable, user-facing behaviour is specified
+- Covering error messages at the exact string level
+
+## Decisions
+
+### One spec file per logical subsystem
+Six capabilities maps cleanly to six spec files. Alternatives considered: one monolithic spec (hard to navigate), two files publish/everything-else (loses granularity). Six files keeps each spec focused and independently referenceable.
+
+### Specify observable behaviour, not internal implementation
+Specs describe WHEN/THEN scenarios a user or test can verify. Internal helpers are not specced — they are implementation details. This makes specs resilient to future refactors.
+
+### Use ADDED Requirements throughout
+Since no prior specs exist for this workflow, all requirements are `ADDED`. There are no `MODIFIED` or `REMOVED` entries.
+
+## Risks / Trade-offs
+
+- [Risk] Specs may drift from the implementation over time → Mitigation: specs are the source of truth; future code changes must update the relevant spec.
+- [Trade-off] Speccing existing behaviour means we might document bugs as intended behaviour → Acceptable; a separate change can fix bugs and update specs simultaneously.

--- a/openspec/changes/document-confluence-workflow/proposal.md
+++ b/openspec/changes/document-confluence-workflow/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+The Confluence workflow in `lua/config/confluence.lua` is a substantial, feature-rich system (publish, pull, comments, conflict detection, filter pipeline) but has no specification document. This makes it hard to understand the intended behaviour, validate that the implementation is correct, and safely extend or modify the workflow in the future. Completely documenting it now creates a stable reference for both human contributors and AI-assisted changes.
+
+## What Changes
+
+- Add a spec for the Confluence publish workflow (markdown → Confluence via pandoc + REST API)
+- Add a spec for the Confluence pull workflow (Confluence → local markdown via pandoc)
+- Add a spec for the Confluence comment-fetch workflow
+- Add a spec for conflict detection (version-tracking via `.confluence-state.json`)
+- Add a spec for the page-map resolution (mapping local files to Confluence URLs)
+- Add a spec for the filter pipeline (`confluence_filter.lua` — link substitution, code macros, PlantUML)
+- No code changes; documentation / specification only
+
+## Capabilities
+
+### New Capabilities
+
+- `confluence-publish`: Full specification of the publish workflow: page-map lookup, script/filter resolution, pandoc conversion, conflict check, and REST PUT
+- `confluence-pull`: Specification of the pull workflow: GET page body, pandoc back-conversion, `.bak` backup, and local file overwrite
+- `confluence-comments`: Specification of the comment-fetch workflow: GET comments, write to sidecar `.comments.md`
+- `confluence-conflict-detection`: Specification of the version-state system (`.confluence-state.json`, stale-version dialog)
+- `confluence-page-map`: Specification of the page-map file format and lookup algorithm
+- `confluence-filter-pipeline`: Specification of the optional Lua filter (link substitution, code macros, PlantUML rendering)
+
+### Modified Capabilities
+
+<!-- No existing specs; all capabilities are new documentation -->
+
+## Impact
+
+- No code changes; no existing behaviour is modified
+- New files: `openspec/specs/confluence-*/spec.md` (6 spec files)
+- Provides a baseline for future confluence-related changes to reference

--- a/openspec/changes/document-confluence-workflow/specs/confluence-comments/spec.md
+++ b/openspec/changes/document-confluence-workflow/specs/confluence-comments/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Fetch all page comments to a sidecar file
+The system SHALL fetch all comments for the mapped Confluence page and write them to `<filename>.comments.md` in the same directory as the source file. If the sidecar file already exists it SHALL be overwritten.
+
+#### Scenario: Successful comment fetch
+- **WHEN** the user runs `,ck` or `:MdConfluenceComments` on a file listed in the page map
+- **THEN** all page comments are fetched and written to `<filename>.comments.md`
+
+#### Scenario: Existing sidecar overwritten
+- **WHEN** `<filename>.comments.md` already exists and the user runs `,ck`
+- **THEN** the existing file is overwritten with fresh comments
+
+#### Scenario: No comments on page
+- **WHEN** the Confluence page has no comments and the user runs `,ck`
+- **THEN** an empty or header-only `<filename>.comments.md` is created and a notification confirms completion
+
+### Requirement: Comment fetch requires valid credentials
+The system SHALL abort with an error if `CONFLUENCE_EMAIL` or `CONFLUENCE_API_TOKEN` are not set.
+
+#### Scenario: Missing credentials on comment fetch
+- **WHEN** either env var is unset and the user runs `,ck`
+- **THEN** an error notification is shown and no network request is made

--- a/openspec/changes/document-confluence-workflow/specs/confluence-conflict-detection/spec.md
+++ b/openspec/changes/document-confluence-workflow/specs/confluence-conflict-detection/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Last-published version is persisted in .confluence-state.json
+The system SHALL record the Confluence page version number in `docs/.confluence-state.json` (relative to the git root) after every successful publish, keyed by the file's relative path. This file SHALL be committed to version control so all team members share the same conflict baseline.
+
+#### Scenario: State written after publish
+- **WHEN** a publish completes successfully
+- **THEN** `docs/.confluence-state.json` is updated with the new page version for the published file
+
+#### Scenario: State file shared across team
+- **WHEN** `.confluence-state.json` is committed and another team member pulls
+- **THEN** their Neovim uses the stored version for conflict detection on the same files
+
+### Requirement: Stale version triggers a confirmation dialog before publish
+The system SHALL compare the live Confluence page version against the stored version before uploading. If the live version is higher than the stored value, it SHALL present a confirmation dialog asking the user whether to overwrite the remote changes.
+
+#### Scenario: Conflict detected — user confirms overwrite
+- **WHEN** the live Confluence version exceeds the stored version and the user confirms the dialog
+- **THEN** the publish proceeds and the state file is updated to the new version
+
+#### Scenario: Conflict detected — user cancels
+- **WHEN** the live Confluence version exceeds the stored version and the user cancels the dialog
+- **THEN** the publish is aborted and the local file and state file are unchanged
+
+#### Scenario: No conflict — publish proceeds silently
+- **WHEN** the live Confluence version matches the stored version
+- **THEN** the confirmation dialog is not shown and publish proceeds immediately

--- a/openspec/changes/document-confluence-workflow/specs/confluence-filter-pipeline/spec.md
+++ b/openspec/changes/document-confluence-workflow/specs/confluence-filter-pipeline/spec.md
@@ -1,7 +1,7 @@
 ## ADDED Requirements
 
 ### Requirement: Filter pipeline enhances pandoc output when confluence_filter.lua is present
-When `confluence_filter.lua` is found (via `CONFLUENCE_FILTER_LUA` env var, `~/.config/nvim/scripts/`, or `<git-root>/scripts/`), the system SHALL pass it to pandoc as a Lua filter during publish, enabling link substitution, code-macro conversion, and PlantUML rendering. If the filter is not found, publish SHALL proceed with basic pandoc conversion only.
+When `confluence_filter.lua` is found (via `CONFLUENCE_FILTER_LUA` env var, `~/.config/nvim/scripts/`, beside `CONFLUENCE_PUBLISH_SCRIPT` when that env var is set, or `<git-root>/scripts/`), the system SHALL pass it to pandoc as a Lua filter during publish, enabling link substitution, code-macro conversion, and PlantUML rendering. If the filter is not found, publish SHALL proceed with basic pandoc conversion only.
 
 #### Scenario: Filter applied when present
 - **WHEN** `confluence_filter.lua` is found in the standard location and `,cc` is run

--- a/openspec/changes/document-confluence-workflow/specs/confluence-filter-pipeline/spec.md
+++ b/openspec/changes/document-confluence-workflow/specs/confluence-filter-pipeline/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: Filter pipeline enhances pandoc output when confluence_filter.lua is present
+When `confluence_filter.lua` is found (via `CONFLUENCE_FILTER_LUA` env var, `~/.config/nvim/scripts/`, or `<git-root>/scripts/`), the system SHALL pass it to pandoc as a Lua filter during publish, enabling link substitution, code-macro conversion, and PlantUML rendering. If the filter is not found, publish SHALL proceed with basic pandoc conversion only.
+
+#### Scenario: Filter applied when present
+- **WHEN** `confluence_filter.lua` is found in the standard location and `,cc` is run
+- **THEN** pandoc is invoked with `--lua-filter=<path>` and the output includes enhanced macros
+
+#### Scenario: Publish succeeds without filter
+- **WHEN** `confluence_filter.lua` is not found in any location
+- **THEN** pandoc runs without a Lua filter and basic conversion output is uploaded
+
+### Requirement: Filter substitutes relative markdown links with Confluence URLs
+The filter SHALL replace relative markdown links (`[text](../other.md)`) with the corresponding Confluence page URL from the page map, so cross-page links remain valid in Confluence.
+
+#### Scenario: Relative link substituted
+- **WHEN** the markdown file contains a relative link to another file that is in the page map
+- **THEN** the published Confluence page contains the Confluence URL in place of the relative path
+
+#### Scenario: Link target not in page map
+- **WHEN** the markdown file contains a relative link to a file not in the page map
+- **THEN** the link is left unchanged in the published output
+
+### Requirement: Filter converts fenced code blocks to Confluence code macros
+The filter SHALL convert standard markdown fenced code blocks to Confluence `ac:structured-macro` code blocks, preserving the language identifier.
+
+#### Scenario: Code block converted to macro
+- **WHEN** the markdown contains ` ```python … ``` `
+- **THEN** the published Confluence page contains an `ac:structured-macro` code block with `language="python"`
+
+### Requirement: Filter renders plantuml fences as inline PNG images
+The filter SHALL send the content of `plantuml` fenced code blocks to the local PlantUML server and embed the resulting PNG as an inline image in the Confluence page.
+
+#### Scenario: PlantUML diagram rendered
+- **WHEN** the markdown contains a ` ```plantuml … ``` ` fence and the PlantUML server is running
+- **THEN** the published Confluence page contains an inline PNG image of the diagram
+
+#### Scenario: PlantUML server unavailable
+- **WHEN** the PlantUML server is not running and a `plantuml` fence is present
+- **THEN** the publish fails or the block is left as a code macro, and an error or warning is shown

--- a/openspec/changes/document-confluence-workflow/specs/confluence-page-map/spec.md
+++ b/openspec/changes/document-confluence-workflow/specs/confluence-page-map/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Page map file maps local paths to Confluence page URLs
+The system SHALL resolve the Confluence page for the current file by reading `docs/confluence-page-map.md` at the git root. Each row in the markdown table SHALL map a local path (relative to `docs/`, with or without a leading `docs/` prefix) to a page title and a full Confluence URL containing a numeric page ID.
+
+#### Scenario: File found in page map
+- **WHEN** the current file's path matches an entry in `docs/confluence-page-map.md`
+- **THEN** the corresponding Confluence URL and title are returned for use by publish, pull, and comments
+
+#### Scenario: Leading docs/ prefix is normalised
+- **WHEN** an entry in the page map is written as `` `docs/lld/foo.md` `` and the current file path is `docs/lld/foo.md`
+- **THEN** the entry is matched correctly regardless of whether the leading `docs/` prefix is present
+
+#### Scenario: File not found in page map
+- **WHEN** the current file has no matching entry in `docs/confluence-page-map.md`
+- **THEN** an error is returned and no network operation is performed
+
+### Requirement: Page map is located relative to the git root
+The system SHALL search for `docs/confluence-page-map.md` relative to the git root of the file being operated on, not relative to the Neovim working directory.
+
+#### Scenario: Page map found via git root
+- **WHEN** the current file is inside a git repository whose root contains `docs/confluence-page-map.md`
+- **THEN** that file is used as the page map
+
+#### Scenario: No git root found
+- **WHEN** the current file is not inside a git repository
+- **THEN** an error is shown and the command aborts

--- a/openspec/changes/document-confluence-workflow/specs/confluence-publish/spec.md
+++ b/openspec/changes/document-confluence-workflow/specs/confluence-publish/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Publish converts local markdown to Confluence storage format
+The system SHALL convert the current buffer's local markdown file to Confluence storage format using `pandoc` and upload it to the mapped Confluence page via the REST API PUT endpoint, updating the page version atomically.
+
+#### Scenario: Successful publish
+- **WHEN** the user runs `,cc` or `:MdToConfluence` on a markdown file listed in the page map
+- **THEN** the file is converted with pandoc, the Confluence page is updated, and a success notification including the page URL is shown
+
+#### Scenario: File not in page map
+- **WHEN** the user runs `,cc` on a file not listed in `docs/confluence-page-map.md`
+- **THEN** an error notification is shown and no API call is made
+
+### Requirement: Publish requires CONFLUENCE_EMAIL and CONFLUENCE_API_TOKEN
+The system SHALL abort publish with an error message if either `CONFLUENCE_EMAIL` or `CONFLUENCE_API_TOKEN` environment variables are not set.
+
+#### Scenario: Missing credentials
+- **WHEN** either env var is unset and the user runs `,cc`
+- **THEN** an error notification `"CONFLUENCE_EMAIL and CONFLUENCE_API_TOKEN must be set"` is shown and no network request is made
+
+### Requirement: Publish script is resolved from standard locations
+The system SHALL locate `confluence_publish.sh` using the following priority order: (1) `CONFLUENCE_PUBLISH_SCRIPT` env var, (2) `~/.config/nvim/scripts/`, (3) `<git-root>/scripts/`. If not found, publish fails with a clear error.
+
+#### Scenario: Script found in standard location
+- **WHEN** `confluence_publish.sh` exists in `~/.config/nvim/scripts/`
+- **THEN** that script is used for the publish
+
+#### Scenario: Script not found
+- **WHEN** `confluence_publish.sh` is not found in any of the three locations
+- **THEN** an error notification is shown and no publish occurs
+
+### Requirement: Publish is non-blocking
+The system SHALL run the publish pipeline asynchronously using `vim.system()` callbacks so the Neovim UI remains responsive during network and pandoc operations.
+
+#### Scenario: UI stays responsive during publish
+- **WHEN** the user triggers `,cc` and the API call is in flight
+- **THEN** the Neovim editor remains interactive and no blocking wait occurs

--- a/openspec/changes/document-confluence-workflow/specs/confluence-pull/spec.md
+++ b/openspec/changes/document-confluence-workflow/specs/confluence-pull/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Pull fetches the Confluence page and writes it to the local file
+The system SHALL fetch the current Confluence page body via GET, convert the storage-format HTML back to markdown using pandoc, and overwrite the local file with the result.
+
+#### Scenario: Successful pull
+- **WHEN** the user runs `,cf` or `:MdFromConfluence` on a file listed in the page map
+- **THEN** the Confluence page content is fetched, converted to markdown, and the local file is overwritten
+
+#### Scenario: File not in page map
+- **WHEN** the user runs `,cf` on a file not in `docs/confluence-page-map.md`
+- **THEN** an error notification is shown and the local file is not modified
+
+### Requirement: Pull creates a .bak backup before overwriting
+The system SHALL create a `.bak` copy of the current local file before overwriting it with the pulled content, ensuring the previous version is recoverable.
+
+#### Scenario: Backup created on pull
+- **WHEN** a successful pull completes
+- **THEN** `<filename>.bak` is created in the same directory containing the previous file contents
+
+### Requirement: Pull requires valid credentials
+The system SHALL abort with an error if `CONFLUENCE_EMAIL` or `CONFLUENCE_API_TOKEN` are not set.
+
+#### Scenario: Missing credentials on pull
+- **WHEN** either env var is unset and the user runs `,cf`
+- **THEN** an error notification is shown and no network request is made

--- a/openspec/changes/document-confluence-workflow/tasks.md
+++ b/openspec/changes/document-confluence-workflow/tasks.md
@@ -1,0 +1,22 @@
+## 1. Spec Files
+
+- [ ] 1.1 Verify `specs/confluence-publish/spec.md` covers publish pipeline, script resolution, and non-blocking behaviour
+- [ ] 1.2 Verify `specs/confluence-pull/spec.md` covers pull, backup creation, and credential check
+- [ ] 1.3 Verify `specs/confluence-comments/spec.md` covers fetch, sidecar overwrite, and credential check
+- [ ] 1.4 Verify `specs/confluence-conflict-detection/spec.md` covers state persistence, stale-version dialog, and no-conflict fast path
+- [ ] 1.5 Verify `specs/confluence-page-map/spec.md` covers map format, path normalisation, git-root resolution, and not-found error
+- [ ] 1.6 Verify `specs/confluence-filter-pipeline/spec.md` covers filter resolution, link substitution, code macros, and PlantUML rendering
+
+## 2. Cross-check Against Implementation
+
+- [ ] 2.1 Read `lua/config/confluence.lua` `M.publish()` and confirm all observable behaviours are covered by `confluence-publish` spec
+- [ ] 2.2 Read `lua/config/confluence.lua` `M.pull()` and confirm all observable behaviours are covered by `confluence-pull` spec
+- [ ] 2.3 Read `lua/config/confluence.lua` `M.fetch_comments()` and confirm all observable behaviours are covered by `confluence-comments` spec
+- [ ] 2.4 Read `state_read()` / `state_write()` and confirm conflict detection spec matches the implementation
+- [ ] 2.5 Read `find_page_entry()` and confirm page-map spec matches the lookup algorithm including path normalisation
+- [ ] 2.6 Read `scripts/confluence_filter.lua` and confirm filter-pipeline spec matches the filter's capabilities
+
+## 3. Documentation Consistency
+
+- [ ] 3.1 Verify `docs/guides/confluence.md` is consistent with the new specs (no contradictions)
+- [ ] 3.2 Update `docs/guides/confluence.md` if any discrepancies are found

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours

--- a/openspec/specs/copilot-cli-integration/spec.md
+++ b/openspec/specs/copilot-cli-integration/spec.md
@@ -1,0 +1,38 @@
+## ADDED Requirements
+
+### Requirement: Suggest command
+The plugin SHALL provide a `:CopilotSuggest` command that passes the current visual selection (or whole buffer when no selection is active) as context to `gh copilot suggest` and displays the response in a floating scratch window.
+
+#### Scenario: Suggest with visual selection
+- **WHEN** the user selects lines in visual mode and runs `:CopilotSuggest`
+- **THEN** the selected text is sent to `gh copilot suggest` and the response is shown in a floating window
+
+#### Scenario: Suggest with no selection
+- **WHEN** the user runs `:CopilotSuggest` with no active visual selection
+- **THEN** the entire buffer content is sent to `gh copilot suggest` and the response is shown in a floating window
+
+#### Scenario: gh CLI not installed
+- **WHEN** `gh` is not found on `$PATH`
+- **THEN** the system SHALL emit a `vim.notify` error and abort without opening a window
+
+### Requirement: Explain command
+The plugin SHALL provide a `:CopilotExplain` command that sends the current visual selection (or whole buffer) to `gh copilot explain` and displays the explanation in a floating scratch window.
+
+#### Scenario: Explain selected code
+- **WHEN** the user selects code and runs `:CopilotExplain`
+- **THEN** the selected text is sent to `gh copilot explain` and the explanation is shown in a floating window
+
+#### Scenario: Explain whole buffer
+- **WHEN** `:CopilotExplain` is run with no selection
+- **THEN** the buffer content is sent and the explanation is shown
+
+### Requirement: Keymap bindings
+The integration SHALL expose `<leader>gcs` for suggest and `<leader>gce` for explain in normal and visual mode via `lua/keymaps.lua`.
+
+#### Scenario: Normal mode suggest keymap
+- **WHEN** the user presses `<leader>gcs` in normal mode
+- **THEN** `:CopilotSuggest` is triggered with the full buffer
+
+#### Scenario: Visual mode explain keymap
+- **WHEN** the user presses `<leader>gce` in visual mode
+- **THEN** `:CopilotExplain` is triggered with the selected lines

--- a/openspec/specs/openspec-integration/spec.md
+++ b/openspec/specs/openspec-integration/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: New change command
+The integration SHALL provide a `:OpenspecNew` command that prompts for a change name and runs `openspec new change "<name>"`, displaying the result in a bottom split scratch buffer.
+
+#### Scenario: Create new change
+- **WHEN** the user runs `:OpenspecNew` and enters a name
+- **THEN** `openspec new change "<name>"` is executed in the repo root and output is shown in a split
+
+#### Scenario: Empty name rejected
+- **WHEN** the user cancels the input prompt or submits an empty name
+- **THEN** the command SHALL abort with no side effects
+
+### Requirement: Status command
+The integration SHALL provide a `:OpenspecStatus` command that runs `openspec status` (or `openspec status --change "<name>"` when a change name is supplied) and shows the output in a bottom split.
+
+#### Scenario: Global status
+- **WHEN** `:OpenspecStatus` is run with no argument
+- **THEN** `openspec status` output is shown in a split
+
+#### Scenario: Change-scoped status
+- **WHEN** `:OpenspecStatus <name>` is run with a change name argument
+- **THEN** `openspec status --change "<name>"` output is shown in a split
+
+### Requirement: List command
+The integration SHALL provide an `:OpenspecList` command that runs `openspec list` and shows available changes in a split.
+
+#### Scenario: List all changes
+- **WHEN** `:OpenspecList` is run
+- **THEN** `openspec list` output is shown in a read-only split buffer
+
+### Requirement: Keymap bindings
+The integration SHALL expose `<leader>osn` (new), `<leader>oss` (status), `<leader>osl` (list) in normal mode via `lua/keymaps.lua`.
+
+#### Scenario: Status keymap
+- **WHEN** the user presses `<leader>oss`
+- **THEN** `:OpenspecStatus` is triggered
+
+#### Scenario: List keymap
+- **WHEN** the user presses `<leader>osl`
+- **THEN** `:OpenspecList` is triggered

--- a/openspec/specs/serena-mcp-server/spec.md
+++ b/openspec/specs/serena-mcp-server/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: MCP server declaration
+The config SHALL declare the Serena MCP server in `vim.g.copilot_mcp_servers` inside `lua/plugins/copilot.lua` so that `copilot.vim` can route code-intelligence requests to it.
+
+#### Scenario: Server declared at startup
+- **WHEN** Neovim starts and `copilot.vim` loads
+- **THEN** `vim.g.copilot_mcp_servers` SHALL contain an entry for Serena with `stdio` transport and the correct launch command
+
+#### Scenario: Serena not running
+- **WHEN** Serena is not installed or not reachable
+- **THEN** `copilot.vim` SHALL skip the server gracefully with no editor error
+
+### Requirement: Launch command configuration
+The Serena entry SHALL use `npx -y @oramasearch/serena` as the default launch command, with the workspace root (`vim.fn.getcwd()`) passed as the working directory.
+
+#### Scenario: npx launch
+- **WHEN** Copilot initiates an MCP request to Serena
+- **THEN** the server process SHALL be spawned via `npx -y @oramasearch/serena` in the current workspace root
+
+#### Scenario: Global install override
+- **WHEN** `serena` is found on `$PATH` (global npm install)
+- **THEN** the config SHALL prefer the global binary over `npx` to avoid startup latency
+
+### Requirement: Documentation
+Installation prerequisites (Node.js, `npx` or global serena package) SHALL be documented in `readme.md` and `docs/guides/ai-tools.md`.
+
+#### Scenario: Readme documents prerequisites
+- **WHEN** a user reads the Serena section of `readme.md`
+- **THEN** they SHALL find the install command and a note about the Node.js requirement

--- a/readme.md
+++ b/readme.md
@@ -372,6 +372,12 @@ You can also press **`<leader>t`** to open the built-in terminal split and run `
 
 → See **[docs/guides/ai-tools.md](docs/guides/ai-tools.md)** for the full guide including OpenSpec and Serena setup.
 
+> **Serena MCP server prerequisites:** Node.js 18+ is required. Install Serena with:
+> ```sh
+> npm install -g @oramasearch/serena
+> ```
+> Or run it without a global install via `npx @oramasearch/serena`.
+
 ## Plugin Overview
 
 Plugins are managed by [lazy.nvim](https://github.com/folke/lazy.nvim) and organized in `lua/plugins/`:

--- a/readme.md
+++ b/readme.md
@@ -261,6 +261,11 @@ Leader key is **Space**.
 | `Alt-f` | Insert | Accept next word of Copilot suggestion |
 | `<leader>t` | Normal | Toggle terminal split |
 | `<leader>f` | Normal / Visual | Format buffer (or selection) |
+| `<leader>gcs` | Normal / Visual | Copilot CLI: suggest (send to `gh copilot suggest`) |
+| `<leader>gce` | Normal / Visual | Copilot CLI: explain (send to `gh copilot explain`) |
+| `<leader>osn` | Normal | OpenSpec: create new change |
+| `<leader>oss` | Normal | OpenSpec: show status |
+| `<leader>osl` | Normal | OpenSpec: list all changes |
 
 ## Auto-Completion
 
@@ -349,13 +354,23 @@ gh extension install github/gh-copilot
 
 ### Using from inside Neovim
 
-Press **`<leader>t`** to open the built-in terminal split, then run `gh copilot` commands directly in the shell:
+Use the built-in keymaps to drive Copilot CLI without leaving the editor:
 
-```sh
-gh copilot suggest "recursively delete all .DS_Store files"
-```
+| Keys | Action |
+|---|---|
+| `<leader>gcs` | Send current selection (or buffer) to `gh copilot suggest` |
+| `<leader>gce` | Send current selection (or buffer) to `gh copilot explain` |
 
-Press **`Esc`** to leave terminal insert mode, then `<C-k>` to jump back to your editor window.
+Results appear in a floating window. Close with `q` or `<Esc>`.
+
+You can also press **`<leader>t`** to open the built-in terminal split and run `gh copilot` commands directly in the shell.
+
+> **Prerequisites:** Install [GitHub CLI](https://cli.github.com/) and the Copilot extension:
+> ```sh
+> gh extension install github/gh-copilot
+> ```
+
+→ See **[docs/guides/ai-tools.md](docs/guides/ai-tools.md)** for the full guide including OpenSpec and Serena setup.
 
 ## Plugin Overview
 
@@ -365,13 +380,13 @@ Plugins are managed by [lazy.nvim](https://github.com/folke/lazy.nvim) and organ
 |---|---|---|
 | `colorscheme.lua` | TokyoNight theme (moon / storm / night / day variants) | — |
 | `conform.lua` | Formatting (format-on-save + `<leader>f`) for Lisp and F# filetypes | [formatting.md](docs/cheatsheets/formatting.md) |
-| `copilot.lua` | Copilot inline completions | [copilot.md](docs/cheatsheets/copilot.md) |
-| `fsharp.lua` | iron.nvim REPL integration for F# (`dotnet fsi`) | [fsharp.md](docs/cheatsheets/fsharp.md) |
+| `copilot.lua` | Copilot inline completions + Serena MCP server config | [copilot.md](docs/cheatsheets/copilot.md) · [ai-tools.md](docs/cheatsheets/ai-tools.md) |
+| `dotnet.lua` | iron.nvim REPL integration for F# (`dotnet fsi`) and C# (`csharprepl`); roslyn.nvim C# LSP | [fsharp.md](docs/cheatsheets/fsharp.md) · [dotnet.md](docs/cheatsheets/dotnet.md) |
 | `fzf-lua.lua` | Fuzzy finder | [fzf.md](docs/cheatsheets/fzf.md) |
 | `git.lua` | vim-fugitive (`:Git` commands) + gitsigns.nvim (hunk signs & staging) | [git.md](docs/cheatsheets/git.md) |
 | `haskell.lua` | haskell-tools.nvim (GHCi REPL + HLS integration) | [haskell.md](docs/cheatsheets/haskell.md) |
 | `html.lua` | Bracey HTML live preview | [html.md](docs/cheatsheets/html.md) |
-| `init.lua` | vim-repeat, vim-sensible, vim-surround, vim-unimpaired, airline, lspconfig | [lsp.md](docs/cheatsheets/lsp.md) · [surround.md](docs/cheatsheets/surround.md) · [unimpaired.md](docs/cheatsheets/unimpaired.md) |
+| `init.lua` | vim-repeat, vim-sensible, vim-surround, vim-unimpaired, vim-airline (statusline), lspconfig | [lsp.md](docs/cheatsheets/lsp.md) · [surround.md](docs/cheatsheets/surround.md) · [unimpaired.md](docs/cheatsheets/unimpaired.md) |
 | `lisp.lua` | Conjure, vim-sexp, nvim-parinfer, rainbow-delimiters | [lisp.md](docs/cheatsheets/lisp.md) |
 | `markdown.lua` | markdown-preview.nvim (browser preview, PlantUML via Docker server); `:MdToPdf` PDF export; `:MdToConfluence` / `:MdFromConfluence` / `:MdConfluenceComments` | [markdown.md](docs/cheatsheets/markdown.md) |
 | `mkdnflow.lua` | mkdnflow.nvim (cross-page link navigation: `<CR>` follow, `<BS>` back) | [markdown.md](docs/cheatsheets/markdown.md) |
@@ -392,18 +407,20 @@ lua/
   loader/init.lua           # lazy.nvim bootstrap
   config/
     confluence.lua          # Confluence publish command (MdToConfluence)
+    copilot_cli.lua         # CopilotSuggest / CopilotExplain commands (gh copilot)
     lsp.lua                 # LSP server setup (cl_lsp, fsautocomplete, marksman)
     marp.lua                # MARP presentation commands (preview + export)
     mdpdf.lua               # Markdown → PDF export command (MdToPdf)
     mdpreview.lua           # Markdown markserv server preview command (MdServerPreview)
+    openspec.lua            # OpenspecNew / OpenspecStatus / OpenspecList commands
     terminal.lua            # Terminal detection & capability flags
     treesitter.lua          # (config managed in plugins/treesitter.lua)
     util.lua                # Shared helpers (open_url: cross-platform browser opener)
   plugins/
     colorscheme.lua         # TokyoNight theme (moon/storm/night/day)
     conform.lua             # Formatting for Lisp and F# filetypes
-    copilot.lua             # Copilot inline completions + model setting
-    fsharp.lua              # F# REPL via iron.nvim (dotnet fsi)
+    copilot.lua             # Copilot inline completions + Serena MCP server config
+    dotnet.lua              # F# + C# REPLs via iron.nvim; roslyn.nvim C# LSP
     fzf-lua.lua             # Fuzzy finder
     git.lua                 # Git (vim-fugitive + gitsigns.nvim)
     haskell.lua             # haskell-tools.nvim (GHCi REPL + HLS)


### PR DESCRIPTION
- Add lua/config/copilot_cli.lua: CopilotSuggest/Explain commands
- Add lua/config/openspec.lua: OpenspecNew/Status/List commands
- Wire both modules in init.lua
- Add keymaps: <leader>gc{s,e} for Copilot CLI, <leader>os{n,s,l} for OpenSpec
- Configure Serena MCP server in lua/plugins/copilot.lua (prefers global binary, falls back to npx)
- Add .github/skills/ and .github/prompts/ for OpenSpec workflow skills
- Add docs/guides/ai-tools.md and docs/cheatsheets/ai-tools.md
- Update docs/cheatsheets/index.md and readme.md
- Add openspec/ directory with config, specs, and change proposals