### PR TITLE
fix: bump GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.2
         with:
           fetch-depth: 0
 
@@ -71,7 +71,7 @@ jobs:
             antora/antora antora-playbook.yml
 
       - name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build/site/arcane-centaur


### PR DESCRIPTION
actions/checkout v4 → v6.0.2 (node24 runtime)
peaceiris/actions-gh-pages v4 → v4.1.0 (node24 runtime)

Both updated to resolve deprecation warning: Node.js 20 actions will be forced to Node.js 24 on June 2, 2026.