### PR TITLE
fix: correct AsciiDoc heading levels and {motion} attribute warnings

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -55,7 +55,7 @@ jobs:
               echo "// :source: $src"
               echo "// Remove this header to take manual ownership of this file"
               echo ""
-              pandoc -f markdown -t asciidoc "$src"
+              pandoc -f markdown -t asciidoc "$src" | awk '/^={2,6} / { sub(/^=/, ""); } { print }'
             } > "$dst"
           }
 

--- a/docs/modules/ROOT/pages/cheatsheets/ai-tools.adoc
+++ b/docs/modules/ROOT/pages/cheatsheets/ai-tools.adoc
@@ -11,7 +11,7 @@ Covers in-editor keymaps for *GitHub Copilot CLI* (`copilot`) and the
 
 '''''
 
-=== GitHub Copilot CLI
+== GitHub Copilot CLI
 
 These commands send the current visual selection (or whole buffer when
 no selection is active) to the `copilot` CLI and display the response in
@@ -27,7 +27,7 @@ command
 selected code
 |===
 
-==== Commands
+=== Commands
 
 [width="100%",cols="50%,50%",options="header",]
 |===
@@ -39,7 +39,7 @@ command suggestion
 explanation
 |===
 
-==== Floating window controls
+=== Floating window controls
 
 [cols=",",options="header",]
 |===
@@ -50,7 +50,7 @@ explanation
 
 '''''
 
-=== OpenSpec
+== OpenSpec
 
 Drive the OpenSpec change workflow from within Neovim. Output is shown
 in a bottom split (close with `q` or `++<++Esc++>++`).
@@ -63,7 +63,7 @@ in a bottom split (close with `q` or `++<++Esc++>++`).
 |`++<++leader++>++osl` |Normal |List all changes (`OpenspecList`)
 |===
 
-==== Commands
+=== Commands
 
 [width="100%",cols="50%,50%",options="header",]
 |===
@@ -79,4 +79,4 @@ specific `++[++name++]++`
 
 '''''
 
-→ xref:guides/ai-tools.adoc[Full guide] · xref:cheatsheets/index.adoc[Back to index]
+→ link:../guides/ai-tools.md[Full guide] · link:index.md[Back to index]

--- a/docs/modules/ROOT/pages/cheatsheets/comments.adoc
+++ b/docs/modules/ROOT/pages/cheatsheets/comments.adoc
@@ -4,9 +4,9 @@
 
 = Comments Cheatsheet (vim-commentary)
 
-→ Back to xref:cheatsheets/index.adoc[main cheatsheet]
+→ Back to link:index.md[main cheatsheet]
 
-=== Comment Toggling
+== Comment Toggling
 
 [width="100%",cols="34%,33%,33%",options="header",]
 |===
@@ -16,7 +16,7 @@
 |`gc` |Visual |Toggle comment on selection
 
 |`gc++<++motion++>++` |Normal |Toggle comment over a motion (e.g. `gcap`
-== paragraph)
+= paragraph)
 
 |`Ctrl-/` |Normal |Toggle comment — use `Ctrl-++_++` on most terminals
 |===

--- a/docs/modules/ROOT/pages/cheatsheets/completion.adoc
+++ b/docs/modules/ROOT/pages/cheatsheets/completion.adoc
@@ -4,9 +4,9 @@
 
 = Auto-Completion Cheatsheet (nvim-cmp)
 
-→ Back to xref:cheatsheets/index.adoc[main cheatsheet]
+→ Back to link:index.md[main cheatsheet]
 
-=== Completion Menu
+== Completion Menu
 
 [cols=",,",options="header",]
 |===
@@ -25,7 +25,7 @@ accidentally confirm the first suggestion. `Ctrl-n` and `Ctrl-p` follow
 Vim’s built-in completion-navigation convention and never block normal
 typing.
 
-=== Completion Sources
+== Completion Sources
 
 [cols=",",options="header",]
 |===
@@ -38,7 +38,7 @@ typing.
 |`cmp-conjure` |Conjure REPL completions (Lisp buffers)
 |===
 
-=== Command-line Completion
+== Command-line Completion
 
 [cols=",",options="header",]
 |===

--- a/docs/modules/ROOT/pages/cheatsheets/copilot.adoc
+++ b/docs/modules/ROOT/pages/cheatsheets/copilot.adoc
@@ -6,9 +6,9 @@
 
 *Leader* = `Space`
 
-→ Back to xref:cheatsheets/index.adoc[main cheatsheet]
+→ Back to link:index.md[main cheatsheet]
 
-=== Inline Suggestions (github/copilot.vim)
+== Inline Suggestions (github/copilot.vim)
 
 [cols=",,",options="header",]
 |===
@@ -19,7 +19,7 @@
 
 `Alt-f` follows the readline/Emacs "`forward-word`" convention (`M-f`).
 
-=== Model Configuration
+== Model Configuration
 
 The active inline-completion model is set in `lua/plugins/copilot.lua`:
 

--- a/docs/modules/ROOT/pages/cheatsheets/dotnet.adoc
+++ b/docs/modules/ROOT/pages/cheatsheets/dotnet.adoc
@@ -8,7 +8,7 @@
 
 '''''
 
-=== C++#++ REPL — iron.nvim {plus} csharprepl
+== C++#++ REPL — iron.nvim {plus} csharprepl
 
 [cols=",,",options="header",]
 |===
@@ -25,7 +25,7 @@
 
 '''''
 
-=== F++#++ REPL — iron.nvim {plus} dotnet fsi
+== F++#++ REPL — iron.nvim {plus} dotnet fsi
 
 [cols=",,",options="header",]
 |===
@@ -42,7 +42,7 @@
 
 '''''
 
-=== LSP (Roslyn — C++#++ buffers only)
+== LSP (Roslyn — C++#++ buffers only)
 
 [cols=",,",options="header",]
 |===
@@ -59,7 +59,7 @@
 
 '''''
 
-=== Roslyn Commands
+== Roslyn Commands
 
 [width="100%",cols="50%,50%",options="header",]
 |===
@@ -68,4 +68,4 @@
 exist)
 |===
 
-→ xref:guides/dotnet.adoc[Full guide]
+→ link:../guides/dotnet.md[Full guide]

--- a/docs/modules/ROOT/pages/cheatsheets/editing.adoc
+++ b/docs/modules/ROOT/pages/cheatsheets/editing.adoc
@@ -6,9 +6,9 @@
 
 *Leader* = `Space`
 
-→ Back to xref:cheatsheets/index.adoc[main cheatsheet]
+→ Back to link:index.md[main cheatsheet]
 
-=== Visual Mode Editing
+== Visual Mode Editing
 
 [cols=",,",options="header",]
 |===
@@ -22,7 +22,7 @@
 |`++<++leader++>++p` |Visual |Paste without overwriting clipboard
 |===
 
-=== System Clipboard
+== System Clipboard
 
 With `clipboard=unnamedplus` set, the default `y`, `d`, and `p` already
 use the system clipboard on most platforms. The shortcuts below use the
@@ -40,7 +40,7 @@ just the unnamed register).
 |`++<++leader++>++P` |Normal |Paste from system clipboard before cursor
 |===
 
-==== Platform notes
+=== Platform notes
 
 [width="100%",cols="34%,33%,33%",options="header",]
 |===
@@ -60,7 +60,7 @@ a supporting terminal
 installer
 |===
 
-→ *xref:guides/clipboard.adoc[Full setup and troubleshooting guide]*
+→ *link:../guides/clipboard.md[Full setup and troubleshooting guide]*
 
 '''''
 

--- a/docs/modules/ROOT/pages/cheatsheets/file-tree.adoc
+++ b/docs/modules/ROOT/pages/cheatsheets/file-tree.adoc
@@ -6,9 +6,9 @@
 
 *Leader* = `Space`
 
-→ Back to xref:cheatsheets/index.adoc[main cheatsheet]
+→ Back to link:index.md[main cheatsheet]
 
-=== Opening the Tree
+== Opening the Tree
 
 [cols=",,",options="header",]
 |===
@@ -18,7 +18,7 @@
 |`Ctrl-f` |Normal |Reveal current file in tree
 |===
 
-=== Inside the Tree Window
+== Inside the Tree Window
 
 These are nvim-tree’s built-in keys (active while the cursor is in the
 tree pane):

--- a/docs/modules/ROOT/pages/cheatsheets/formatting.adoc
+++ b/docs/modules/ROOT/pages/cheatsheets/formatting.adoc
@@ -6,9 +6,9 @@
 
 *Leader* = `Space`
 
-→ Back to xref:cheatsheets/index.adoc[main cheatsheet]
+→ Back to link:index.md[main cheatsheet]
 
-=== Format Keybinding
+== Format Keybinding
 
 [width="100%",cols="34%,33%,33%",options="header",]
 |===
@@ -17,7 +17,7 @@
 (LSP-preferred)
 |===
 
-=== Format-on-Save
+== Format-on-Save
 
 Format-on-save is enabled automatically for the following filetypes:
 

--- a/docs/modules/ROOT/pages/cheatsheets/fsharp.adoc
+++ b/docs/modules/ROOT/pages/cheatsheets/fsharp.adoc
@@ -6,10 +6,10 @@
 
 *LocalLeader* = `,` in F++#++ buffers
 
-→ Back to xref:cheatsheets/index.adoc[main cheatsheet] · Full guide:
+→ Back to link:index.md[main cheatsheet] · Full guide:
 ../guides/fsharp.md
 
-=== REPL Interaction (dotnet fsi)
+== REPL Interaction (dotnet fsi)
 
 The REPL opens as a horizontal split at the bottom (40% height).
 
@@ -26,7 +26,7 @@ The REPL opens as a horizontal split at the bottom (40% height).
 |`,cl` |Normal |Clear the REPL output buffer
 |===
 
-=== LSP (fsautocomplete)
+== LSP (fsautocomplete)
 
 Standard LSP keys are active in F++#++ buffers — see lsp.md.
 Format-on-save is handled by conform.nvim — see formatting.md.

--- a/docs/modules/ROOT/pages/cheatsheets/fzf.adoc
+++ b/docs/modules/ROOT/pages/cheatsheets/fzf.adoc
@@ -4,9 +4,9 @@
 
 = Fuzzy Finder Cheatsheet (fzf-lua)
 
-→ Back to xref:cheatsheets/index.adoc[main cheatsheet]
+→ Back to link:index.md[main cheatsheet]
 
-=== Built-in fzf-lua Keybindings
+== Built-in fzf-lua Keybindings
 
 fzf-lua uses the default fzf key bindings inside its popup window. Open
 the picker with any `:FzfLua ++<++command++>++` call. Common built-in
@@ -26,7 +26,7 @@ keys:
 |`Ctrl-d` |Deselect all items
 |===
 
-=== Example Commands
+== Example Commands
 
 Run these from the Neovim command line or bind them to keys in
 `lua/keymaps.lua`:

--- a/docs/modules/ROOT/pages/cheatsheets/git.adoc
+++ b/docs/modules/ROOT/pages/cheatsheets/git.adoc
@@ -6,11 +6,11 @@
 
 *Leader* = `Space`
 
-→ Back to xref:cheatsheets/index.adoc[main cheatsheet]
+→ Back to link:index.md[main cheatsheet]
 
 '''''
 
-=== vim-fugitive — Git Operations
+== vim-fugitive — Git Operations
 
 Run any git command with `:Git ++<++args++>++` or its short alias
 `:G ++<++args++>++` (e.g. `:Git commit`, `:G rebase -i HEAD~3`).
@@ -25,7 +25,7 @@ Run any git command with `:Git ++<++args++>++` or its short alias
 |`++<++leader++>++gp` |Normal |Git push
 |===
 
-==== Inside the `:Git` status window
+=== Inside the `:Git` status window
 
 [cols=",",options="header",]
 |===
@@ -40,12 +40,12 @@ Run any git command with `:Git ++<++args++>++` or its short alias
 
 '''''
 
-=== gitsigns.nvim — In-Buffer Git Signs
+== gitsigns.nvim — In-Buffer Git Signs
 
 Changed lines are marked in the sign column: `▎` added · `▎` changed ·
 `▁`/`▔` deleted line
 
-==== Hunk Navigation
+=== Hunk Navigation
 
 [cols=",,",options="header",]
 |===
@@ -54,7 +54,7 @@ Changed lines are marked in the sign column: `▎` added · `▎` changed ·
 |`++[++h` |Normal |Jump to previous hunk
 |===
 
-==== Hunk Actions
+=== Hunk Actions
 
 [cols=",,",options="header",]
 |===
@@ -70,7 +70,7 @@ Changed lines are marked in the sign column: `▎` added · `▎` changed ·
 |`++<++leader++>++hD` |Normal |Diff this file (staged, vs. HEAD)
 |===
 
-==== Text Object
+=== Text Object
 
 [cols=",,",options="header",]
 |===
@@ -86,6 +86,26 @@ for Hoogle search in `.hs` files. The buffer-local haskell binding takes
 precedence there; use the fugitive status window (`:Git`) to stage
 changes while editing Haskell.
 ____
+
+'''''
+
+== diffview.nvim — Side-by-Side Diff & File History
+
+Opens a persistent tabbed diff panel with a file list on the left and a
+two-pane diff on the right. Also provides per-file commit history and a
+three-way merge conflict view.
+
+[cols=",,",options="header",]
+|===
+|Keys |Mode |Action
+|`++<++leader++>++gD` |Normal |Open diff view (all working tree changes)
+|`++<++leader++>++gH` |Normal |Open file history for current file
+|`++<++leader++>++gX` |Normal |Close diff view
+|===
+
+You can also open diffview against any ref directly: -
+`:DiffviewOpen HEAD~3` — diff working tree vs 3 commits ago -
+`:DiffviewFileHistory` — history for all files (omit `%` for repo-wide)
 
 '''''
 

--- a/docs/modules/ROOT/pages/cheatsheets/haskell.adoc
+++ b/docs/modules/ROOT/pages/cheatsheets/haskell.adoc
@@ -6,10 +6,10 @@
 
 *Leader* = `Space`
 
-→ Back to xref:cheatsheets/index.adoc[main cheatsheet] · Full guide:
+→ Back to link:index.md[main cheatsheet] · Full guide:
 ../guides/haskell.md
 
-=== GHCi REPL
+== GHCi REPL
 
 [cols=",,",options="header",]
 |===
@@ -19,7 +19,7 @@
 |`++<++leader++>++rq` |Normal |Quit the GHCi REPL
 |===
 
-=== haskell-tools Extras
+== haskell-tools Extras
 
 [cols=",,",options="header",]
 |===
@@ -29,7 +29,7 @@
 |`Space-ea` |Normal |Evaluate all code snippets in the buffer
 |===
 
-=== LSP (haskell-language-server)
+== LSP (haskell-language-server)
 
 haskell-tools manages the HLS connection automatically. The standard LSP
 keys (`gd`, `K`, `gr`, `++<++leader++>++rn`, `++<++leader++>++ca`,

--- a/docs/modules/ROOT/pages/cheatsheets/html.adoc
+++ b/docs/modules/ROOT/pages/cheatsheets/html.adoc
@@ -6,9 +6,9 @@
 
 *LocalLeader* = `,` in HTML / CSS / JavaScript buffers
 
-→ Back to xref:cheatsheets/index.adoc[main cheatsheet]
+→ Back to link:index.md[main cheatsheet]
 
-=== Live Preview (bracey.vim)
+== Live Preview (bracey.vim)
 
 [cols=",,",options="header",]
 |===
@@ -22,7 +22,7 @@ Bracey starts a local server and opens the current HTML file in the
 default browser. Changes to the HTML, CSS, or JavaScript are reflected
 live without a manual reload.
 
-=== Prerequisites
+== Prerequisites
 
 The plugin’s Node.js server dependency is built automatically on first
 install:

--- a/docs/modules/ROOT/pages/cheatsheets/index.adoc
+++ b/docs/modules/ROOT/pages/cheatsheets/index.adoc
@@ -6,47 +6,47 @@
 
 *Leader* = `Space` · *LocalLeader* = `,` (in all language buffers)
 
-=== Plugin Cheatsheets
+== Plugin Cheatsheets
 
 [width="100%",cols="50%,50%",options="header",]
 |===
 |Plugin / Area |Cheatsheet
-|Auto-Completion (nvim-cmp) |xref:cheatsheets/completion.adoc[completion.adoc]
+|Auto-Completion (nvim-cmp) |completion.md
 
-|Clipboard |xref:cheatsheets/editing.adoc#system-clipboard[editing.adoc] —
-xref:guides/clipboard.adoc[full guide]
+|Clipboard |link:editing.md#system-clipboard[editing.md] —
+link:../guides/clipboard.md[full guide]
 
-|Comments (vim-commentary) |xref:cheatsheets/comments.adoc[comments.adoc]
+|Comments (vim-commentary) |comments.md
 
-|C++#++ / .NET (Roslyn {plus} iron.nvim) |xref:cheatsheets/dotnet.adoc[dotnet.adoc]
+|C++#++ / .NET (Roslyn {plus} iron.nvim) |dotnet.md
 
-|F++#++ REPL (iron.nvim) |xref:cheatsheets/fsharp.adoc[fsharp.adoc]
+|F++#++ REPL (iron.nvim) |fsharp.md
 
-|File Tree (nvim-tree) |xref:cheatsheets/file-tree.adoc[file-tree.adoc]
+|File Tree (nvim-tree) |file-tree.md
 
-|Formatting (conform.nvim) |xref:cheatsheets/formatting.adoc[formatting.adoc]
+|Formatting (conform.nvim) |formatting.md
 
-|Fuzzy Finder (fzf-lua) |xref:cheatsheets/fzf.adoc[fzf.adoc]
+|Fuzzy Finder (fzf-lua) |fzf.md
 
-|Git (vim-fugitive {plus} gitsigns) |xref:cheatsheets/git.adoc[git.adoc]
+|Git (vim-fugitive {plus} gitsigns) |git.md
 
-|GitHub Copilot |xref:cheatsheets/copilot.adoc[copilot.adoc]
+|GitHub Copilot |copilot.md
 
-|GitHub Copilot CLI {plus} OpenSpec |xref:cheatsheets/ai-tools.adoc[ai-tools.adoc]
+|GitHub Copilot CLI {plus} OpenSpec |ai-tools.md
 
-|Haskell (haskell-tools) |xref:cheatsheets/haskell.adoc[haskell.adoc]
+|Haskell (haskell-tools) |haskell.md
 
-|Janet (Conjure {plus} vim-sexp) |xref:cheatsheets/janet.adoc[janet.adoc]
+|Janet (Conjure {plus} vim-sexp) |janet.md
 
-|HTML Live Preview (Bracey) |xref:cheatsheets/html.adoc[html.adoc]
+|HTML Live Preview (Bracey) |html.md
 
-|Lisp / Clojure / Scheme / Fennel (Conjure {plus} vim-sexp) |xref:cheatsheets/lisp.adoc[lisp.adoc]
+|Lisp / Clojure / Scheme / Fennel (Conjure {plus} vim-sexp) |lisp.md
 
-|LSP |xref:cheatsheets/lsp.adoc[lsp.adoc]
+|LSP |lsp.md
 
-|Markdown Preview {plus} MARP {plus} Confluence {plus} Jira |xref:cheatsheets/markdown.adoc[markdown.adoc]
+|Markdown Preview {plus} MARP {plus} Confluence {plus} Jira |markdown.md
 
-|Navigation & Splits |xref:cheatsheets/navigation.adoc[navigation.adoc]
+|Navigation & Splits |navigation.md
 
 |PlantUML Preview |plantuml.md
 
@@ -61,9 +61,9 @@ xref:guides/clipboard.adoc[full guide]
 
 '''''
 
-=== Quick Reference
+== Quick Reference
 
-==== Navigation & Splits
+=== Navigation & Splits
 
 [cols=",,",options="header",]
 |===
@@ -78,11 +78,11 @@ xref:guides/clipboard.adoc[full guide]
 |`Ctrl-→` |Normal |Grow split width
 |===
 
-→ xref:cheatsheets/navigation.adoc[Full reference]
+→ link:navigation.md[Full reference]
 
 '''''
 
-==== File Tree (nvim-tree)
+=== File Tree (nvim-tree)
 
 [cols=",,",options="header",]
 |===
@@ -92,11 +92,11 @@ xref:guides/clipboard.adoc[full guide]
 |`Ctrl-f` |Normal |Reveal current file in tree
 |===
 
-→ xref:cheatsheets/file-tree.adoc[Full reference]
+→ link:file-tree.md[Full reference]
 
 '''''
 
-==== Terminal
+=== Terminal
 
 [cols=",,",options="header",]
 |===
@@ -105,11 +105,11 @@ xref:guides/clipboard.adoc[full guide]
 |`Esc` |Terminal |Exit terminal insert mode
 |===
 
-→ xref:cheatsheets/navigation.adoc[Full reference]
+→ link:navigation.md[Full reference]
 
 '''''
 
-==== Editing
+=== Editing
 
 [cols=",,",options="header",]
 |===
@@ -123,7 +123,7 @@ xref:guides/clipboard.adoc[full guide]
 |`++<++leader++>++p` |Visual |Paste without overwriting clipboard
 |===
 
-==== System Clipboard
+=== System Clipboard
 
 [cols=",,",options="header",]
 |===
@@ -143,11 +143,11 @@ cursor)
 Works on GUI Linux (xclip/xsel/wl-clipboard), WSL (win32yank.exe), and
 SSH/TTY sessions (OSC 52 — no external tool required).
 
-→ xref:cheatsheets/editing.adoc[Full reference]
+→ link:editing.md[Full reference]
 
 '''''
 
-==== Comments (vim-commentary)
+=== Comments (vim-commentary)
 
 [cols=",,",options="header",]
 |===
@@ -158,11 +158,11 @@ SSH/TTY sessions (OSC 52 — no external tool required).
 |`Ctrl-/` |Normal |Toggle comment (Kitty / WezTerm)
 |===
 
-→ xref:cheatsheets/comments.adoc[Full reference]
+→ link:comments.md[Full reference]
 
 '''''
 
-==== Formatting (conform.nvim)
+=== Formatting (conform.nvim)
 
 [width="100%",cols="34%,33%,33%",options="header",]
 |===
@@ -174,11 +174,11 @@ SSH/TTY sessions (OSC 52 — no external tool required).
 _Format-on-save is enabled for Lisp, Clojure, Scheme, Fennel, Janet, and
 F++#++ buffers._
 
-→ xref:cheatsheets/formatting.adoc[Full reference]
+→ link:formatting.md[Full reference]
 
 '''''
 
-==== Copilot
+=== Copilot
 
 [width="100%",cols="34%,33%,33%",options="header",]
 |===
@@ -200,11 +200,11 @@ window)
 window)
 |===
 
-→ xref:cheatsheets/copilot.adoc[Full reference] · xref:cheatsheets/ai-tools.adoc[AI Tools guide]
+→ link:copilot.md[Full reference] · link:ai-tools.md[AI Tools guide]
 
 '''''
 
-==== OpenSpec
+=== OpenSpec
 
 [cols=",,",options="header",]
 |===
@@ -214,11 +214,11 @@ window)
 |`++<++leader++>++osl` |Normal |List all OpenSpec changes
 |===
 
-→ xref:cheatsheets/ai-tools.adoc[Full reference]
+→ link:ai-tools.md[Full reference]
 
 '''''
 
-==== LSP (all LSP-enabled buffers)
+=== LSP (all LSP-enabled buffers)
 
 [cols=",,",options="header",]
 |===
@@ -233,11 +233,11 @@ window)
 |`++]++d` |Normal |Next diagnostic
 |===
 
-→ xref:cheatsheets/lsp.adoc[Full reference]
+→ link:lsp.md[Full reference]
 
 '''''
 
-==== Auto-Completion (nvim-cmp)
+=== Auto-Completion (nvim-cmp)
 
 [cols=",,",options="header",]
 |===
@@ -251,11 +251,11 @@ window)
 |`Ctrl-b` |Insert |Scroll docs preview up
 |===
 
-→ xref:cheatsheets/completion.adoc[Full reference]
+→ link:completion.md[Full reference]
 
 '''''
 
-==== Git — vim-fugitive {plus} gitsigns
+=== Git — vim-fugitive {plus} gitsigns {plus} diffview.nvim
 
 [cols=",,",options="header",]
 |===
@@ -271,13 +271,16 @@ window)
 |`++<++leader++>++hr` |Normal / Visual |Reset hunk
 |`++<++leader++>++hu` |Normal |Undo stage
 |`++<++leader++>++hb` |Normal |Blame line
+|`++<++leader++>++gD` |Normal |Open diff view (working tree)
+|`++<++leader++>++gH` |Normal |File history for current file
+|`++<++leader++>++gX` |Normal |Close diff view
 |===
 
-→ xref:cheatsheets/git.adoc[Full reference]
+→ link:git.md[Full reference]
 
 '''''
 
-==== Haskell (haskell-tools)
+=== Haskell (haskell-tools)
 
 Leader is `Space`; no LocalLeader bindings are used in Haskell buffers.
 
@@ -292,11 +295,11 @@ Leader is `Space`; no LocalLeader bindings are used in Haskell buffers.
 |`Space-ea` |Normal |Evaluate all code snippets
 |===
 
-→ xref:cheatsheets/haskell.adoc[Full reference] · xref:guides/haskell.adoc[Guide]
+→ link:haskell.md[Full reference] · link:../guides/haskell.md[Guide]
 
 '''''
 
-==== F++#++ REPL — iron.nvim
+=== F++#++ REPL — iron.nvim
 
 LocalLeader is `,` in F++#++ buffers.
 
@@ -313,15 +316,15 @@ LocalLeader is `,` in F++#++ buffers.
 |`,cl` |Normal |Clear REPL output
 |===
 
-→ xref:cheatsheets/fsharp.adoc[Full reference] · xref:guides/fsharp.adoc[Guide]
+→ link:fsharp.md[Full reference] · link:../guides/fsharp.md[Guide]
 
 '''''
 
-==== Lisp / Clojure / Scheme / Janet — Conjure
+=== Lisp / Clojure / Scheme / Janet — Conjure
 
 LocalLeader is `,` in Lisp/Clojure/Scheme/Fennel/Janet buffers.
 
-===== Evaluation
+==== Evaluation
 
 [cols=",",options="header",]
 |===
@@ -333,7 +336,7 @@ LocalLeader is `,` in Lisp/Clojure/Scheme/Fennel/Janet buffers.
 |`,cc` |Connect to REPL manually
 |===
 
-===== REPL Log
+==== REPL Log
 
 [cols=",",options="header",]
 |===
@@ -343,11 +346,11 @@ LocalLeader is `,` in Lisp/Clojure/Scheme/Fennel/Janet buffers.
 |`,lq` |Close REPL log window
 |===
 
-→ xref:cheatsheets/lisp.adoc[Full reference] · xref:guides/lisp.adoc[Guide]
+→ link:lisp.md[Full reference] · link:../guides/lisp.md[Guide]
 
 '''''
 
-==== Structural Editing — vim-sexp
+=== Structural Editing — vim-sexp
 
 [cols=",",options="header",]
 |===
@@ -365,11 +368,11 @@ LocalLeader is `,` in Lisp/Clojure/Scheme/Fennel/Janet buffers.
 |`dsf` |Delete surrounding function call (splice)
 |===
 
-→ xref:cheatsheets/lisp.adoc[Full reference]
+→ link:lisp.md[Full reference]
 
 '''''
 
-==== Markdown
+=== Markdown
 
 LocalLeader is `,` in Markdown buffers.
 
@@ -381,6 +384,7 @@ LocalLeader is `,` in Markdown buffers.
 |`++<++Tab++>++` |Jump to next link in buffer (mkdnflow)
 |`++<++S-Tab++>++` |Jump to previous link in buffer (mkdnflow)
 |`,p` |Toggle Markdown browser preview (single-file)
+|`,pp` |Popup preview via glow (always available)
 |`,sp` |Open in markserv Docker server preview (cross-page links)
 |`,dp` |Export to PDF with PlantUML diagrams rendered
 |`,mp` |MARP: open slide in preview server
@@ -394,14 +398,14 @@ LocalLeader is `,` in Markdown buffers.
 |`,js` |Create Jira Story (prompts for summary {plus} description)
 |===
 
-→ xref:cheatsheets/markdown.adoc[Full reference] · xref:guides/diagrams.adoc[Diagrams
-guide] · xref:guides/presentations.adoc[Presentations guide] ·
-xref:guides/confluence.adoc[Confluence guide] ·
-xref:guides/jira.adoc[Jira guide]
+→ link:markdown.md[Full reference] · link:../guides/diagrams.md[Diagrams
+guide] · link:../guides/presentations.md[Presentations guide] ·
+link:../guides/confluence.md[Confluence guide] ·
+link:../guides/jira.md[Jira guide]
 
 '''''
 
-==== PlantUML
+=== PlantUML
 
 LocalLeader is `,` in PlantUML buffers.
 
@@ -412,11 +416,11 @@ LocalLeader is `,` in PlantUML buffers.
 |`++<++leader++>++pa` |Open ASCII preview popup
 |===
 
-→ xref:cheatsheets/plantuml.adoc[Full reference]
+→ link:plantuml.md[Full reference]
 
 '''''
 
-==== HTML Live Preview (Bracey)
+=== HTML Live Preview (Bracey)
 
 LocalLeader is `,` in HTML / CSS / JavaScript buffers.
 
@@ -428,11 +432,11 @@ LocalLeader is `,` in HTML / CSS / JavaScript buffers.
 |`,r` |Reload the live preview
 |===
 
-→ xref:cheatsheets/html.adoc[Full reference]
+→ link:html.md[Full reference]
 
 '''''
 
-==== REST Client (kulala.nvim)
+=== REST Client (kulala.nvim)
 
 LocalLeader is `,` in `.http` buffers.
 
@@ -445,4 +449,4 @@ LocalLeader is `,` in `.http` buffers.
 |`,e` |Select environment
 |===
 
-→ xref:cheatsheets/rest.adoc[Full reference] · xref:guides/rest.adoc[Guide]
+→ link:rest.md[Full reference] · link:../guides/rest.md[Guide]

--- a/docs/modules/ROOT/pages/cheatsheets/janet.adoc
+++ b/docs/modules/ROOT/pages/cheatsheets/janet.adoc
@@ -6,10 +6,10 @@
 
 *LocalLeader* = `,` in Janet buffers
 
-→ Back to xref:cheatsheets/index.adoc[main cheatsheet] · Full guide:
+→ Back to link:index.md[main cheatsheet] · Full guide:
 ../guides/janet.md
 
-=== Conjure — Evaluation
+== Conjure — Evaluation
 
 [cols=",",options="header",]
 |===
@@ -20,7 +20,7 @@
 |`,e!` |Replace form with its evaluated result
 |===
 
-=== Conjure — REPL Log
+== Conjure — REPL Log
 
 [cols=",",options="header",]
 |===
@@ -30,7 +30,7 @@
 |`,lq` |Close REPL log window
 |===
 
-=== Structural Editing — vim-sexp
+== Structural Editing — vim-sexp
 
 [width="100%",cols="50%,50%",options="header",]
 |===
@@ -66,7 +66,7 @@ ____
 See ../guides/janet.md for step-by-step examples and setup instructions.
 ____
 
-=== Other Active Plugins
+== Other Active Plugins
 
 * *nvim-parinfer* — keeps parentheses balanced as you edit indentation
 (no keymaps)

--- a/docs/modules/ROOT/pages/cheatsheets/lisp.adoc
+++ b/docs/modules/ROOT/pages/cheatsheets/lisp.adoc
@@ -6,10 +6,10 @@
 
 *LocalLeader* = `,` in Lisp / Clojure / Scheme / Fennel buffers
 
-→ Back to xref:cheatsheets/index.adoc[main cheatsheet] · Full guide: ../guides/lisp.adoc
+→ Back to link:index.md[main cheatsheet] · Full guide: ../guides/lisp.md
 · Janet-specific: janet.md
 
-=== Conjure — Evaluation
+== Conjure — Evaluation
 
 [cols=",",options="header",]
 |===
@@ -21,7 +21,7 @@
 |`,cc` |Connect to REPL manually
 |===
 
-=== Conjure — REPL Log
+== Conjure — REPL Log
 
 [cols=",",options="header",]
 |===
@@ -31,7 +31,7 @@
 |`,lq` |Close REPL log window
 |===
 
-=== Structural Editing — vim-sexp
+== Structural Editing — vim-sexp
 
 [width="100%",cols="50%,50%",options="header",]
 |===
@@ -65,11 +65,11 @@ the first element _out of_ the form
 
 ____
 See
-xref:guides/lisp.adoc#structural-editing-slurp--barf[../guides/lisp.adoc]
+link:++../guides/lisp.md#structural-editing-slurp--barf++[../guides/lisp.md]
 for step-by-step examples of each slurp/barf operation.
 ____
 
-=== Other Active Plugins
+== Other Active Plugins
 
 * *nvim-parinfer* — keeps parentheses balanced as you edit indentation
 (no keymaps)

--- a/docs/modules/ROOT/pages/cheatsheets/lsp.adoc
+++ b/docs/modules/ROOT/pages/cheatsheets/lsp.adoc
@@ -6,9 +6,9 @@
 
 *Leader* = `Space`
 
-→ Back to xref:cheatsheets/index.adoc[main cheatsheet]
+→ Back to link:index.md[main cheatsheet]
 
-=== LSP Keybindings (all LSP-enabled buffers)
+== LSP Keybindings (all LSP-enabled buffers)
 
 These keymaps are active in any buffer where an LSP server has attached
 (F++#++, C++#++, Markdown, Haskell).
@@ -26,7 +26,7 @@ These keymaps are active in any buffer where an LSP server has attached
 |`++]++d` |Normal |Jump to next diagnostic
 |===
 
-=== Configured LSP Servers
+== Configured LSP Servers
 
 [width="100%",cols="34%,33%,33%",options="header",]
 |===

--- a/docs/modules/ROOT/pages/cheatsheets/markdown.adoc
+++ b/docs/modules/ROOT/pages/cheatsheets/markdown.adoc
@@ -6,12 +6,12 @@
 
 *LocalLeader* = `,` in Markdown buffers
 
-→ Back to xref:cheatsheets/index.adoc[main cheatsheet] · Markdown guide:
+→ Back to link:index.md[main cheatsheet] · Markdown guide:
 ../guides/markdown.md · Diagrams guide: ../guides/diagrams.md ·
 Presentations guide: ../guides/presentations.md · Confluence guide:
 ../guides/confluence.md · Jira guide: ../guides/jira.md
 
-=== Cross-page Link Navigation (mkdnflow.nvim)
+== Cross-page Link Navigation (mkdnflow.nvim)
 
 [width="100%",cols="34%,33%,33%",options="header",]
 |===
@@ -31,24 +31,52 @@ directly in the editor, then press `,p` or `,sp` to open the browser
 preview for that file. Press `++<++BS++>++` to return to the original
 file.
 
-=== Markdown Preview (markdown-preview.nvim)
+== Markdown Preview (markdown-preview.nvim {plus} glow.nvim)
 
 [width="100%",cols="34%,33%,33%",options="header",]
 |===
 |Keys |Mode |Action
-|`,p` |Normal |Toggle live browser preview (`MarkdownPreviewToggle`)
+|`,p` |Normal |Toggle live browser preview (`MarkdownPreviewToggle`) —
+GUI; or glow popup in console
+
+|`,pp` |Normal |Force glow popup preview — always opens in-terminal,
+regardless of environment
 |===
 
-The preview auto-refreshes as you edit. *Mermaid fenced code blocks
-render natively* in the browser — no extra plugin or Docker server
-required. PlantUML fenced code blocks are rendered via the PlantUML
-Docker server (`http://localhost:8080`).
+The browser preview (`,p` in GUI) auto-refreshes as you edit. *Mermaid
+fenced code blocks render natively* in the browser — no extra plugin or
+Docker server required. PlantUML fenced code blocks are rendered via the
+PlantUML Docker server (`http://localhost:8080`).
+
+Use `,pp` when working full-screen in a terminal and you don’t want to
+context-switch to a browser.
 
 *Limitation:* only the current buffer is served; clicking relative links
 to other `.md` files returns 404. Use the markserv server (`,sp`) for
 projects with cross-page links.
 
-=== Project Preview with Cross-page Links — markserv (requires Docker)
+== AsciiDoc Preview (asciidoctor via Docker)
+
+The same `,p` and `,pp` keymaps work in `.adoc` buffers. Both trigger
+the same one-shot convert-and-open HTML flow — there is no popup
+equivalent for AsciiDoc output.
+
+[width="100%",cols="34%,33%,33%",options="header",]
+|===
+|Keys |Mode |Action
+|`,p` |Normal |Convert `.adoc` to HTML (Docker asciidoctor) and open in
+system browser — GUI only
+
+|`,pp` |Normal |Same as `,p` (no popup equivalent for HTML output)
+|===
+
+Requires Docker running. The `asciidoctor/docker-asciidoctor` image is
+pulled automatically on first use (~200 MB).
+
+*Console mode:* both `,p` and `,pp` show a notification that AsciiDoc
+preview requires a graphical environment.
+
+== Project Preview with Cross-page Links — markserv (requires Docker)
 
 [width="100%",cols="34%,33%,33%",options="header",]
 |===
@@ -89,7 +117,7 @@ render natively* in the browser — no extra plugin or Docker server
 required. PlantUML fenced code blocks are rendered via the PlantUML
 Docker server (`http://localhost:8080`).
 
-=== Export to PDF with PlantUML and Mermaid diagrams (requires Docker)
+== Export to PDF with PlantUML and Mermaid diagrams (requires Docker)
 
 [width="100%",cols="34%,33%,33%",options="header",]
 |===
@@ -103,9 +131,9 @@ Requires the PlantUML server
 Docker image (`docker pull pandoc/extra`). Mermaid blocks are rendered
 via the https://kroki.io[Kroki] public API (internet access required).
 The PDF is written to the same directory as the source file. See
-xref:guides/diagrams.adoc#exporting-to-pdf[../guides/diagrams.adoc].
+link:../guides/diagrams.md#exporting-to-pdf[../guides/diagrams.md].
 
-=== MARP Presentations (requires Docker)
+== MARP Presentations (requires Docker)
 
 [cols=",,",options="header",]
 |===
@@ -125,7 +153,7 @@ using `,mp`:
 docker compose -f ~/.config/nvim/docker/marp/docker-compose.yml up -d
 ----
 
-=== Confluence Publishing (requires env vars {plus} pandoc {plus} curl)
+== Confluence Publishing (requires env vars {plus} pandoc {plus} curl)
 
 [width="100%",cols="34%,33%,33%",options="header",]
 |===
@@ -144,7 +172,7 @@ environment variables and a `docs/confluence-page-map.md` page map in
 the repository root. See ../guides/confluence.md for full setup
 instructions.
 
-=== Jira Issue & Story Creation (requires env vars {plus} curl)
+== Jira Issue & Story Creation (requires env vars {plus} curl)
 
 [cols=",,",options="header",]
 |===
@@ -160,7 +188,7 @@ Requires `JIRA++_++EMAIL`, `JIRA++_++API++_++TOKEN`, and
 `docs/jira-project-map.md` project map in the repository root. See
 ../guides/jira.md for full setup instructions.
 
-=== User Commands
+== User Commands
 
 [width="100%",cols="50%,50%",options="header",]
 |===

--- a/docs/modules/ROOT/pages/cheatsheets/navigation.adoc
+++ b/docs/modules/ROOT/pages/cheatsheets/navigation.adoc
@@ -6,9 +6,9 @@
 
 *Leader* = `Space`
 
-→ Back to xref:cheatsheets/index.adoc[main cheatsheet]
+→ Back to link:index.md[main cheatsheet]
 
-=== Window / Split Navigation
+== Window / Split Navigation
 
 [cols=",,",options="header",]
 |===
@@ -23,7 +23,7 @@
 |`Ctrl-→` |Normal |Grow split width
 |===
 
-=== Terminal
+== Terminal
 
 [width="100%",cols="34%,33%,33%",options="header",]
 |===
@@ -38,7 +38,7 @@ The terminal toggle reuses the same terminal buffer across open/close
 cycles. Press `++<++C-k++>++` after `Esc` to jump back to the editor
 window.
 
-=== Copilot Chat Window
+== Copilot Chat Window
 
 [width="100%",cols="34%,33%,33%",options="header",]
 |===

--- a/docs/modules/ROOT/pages/cheatsheets/plantuml.adoc
+++ b/docs/modules/ROOT/pages/cheatsheets/plantuml.adoc
@@ -6,10 +6,10 @@
 
 *LocalLeader* = `,` in PlantUML buffers
 
-→ Back to xref:cheatsheets/index.adoc[main cheatsheet] · Full guide:
-xref:guides/diagrams.adoc[Diagrams guide]
+→ Back to link:index.md[main cheatsheet] · Full guide:
+../guides/diagrams.md
 
-=== Preview
+== Preview
 
 [width="100%",cols="34%,33%,33%",options="header",]
 |===
@@ -20,7 +20,7 @@ xref:guides/diagrams.adoc[Diagrams guide]
 (`PumlPreviewAscii`)
 |===
 
-=== User Command
+== User Command
 
 [width="100%",cols="50%,50%",options="header",]
 |===
@@ -38,7 +38,7 @@ base64 scheme via `python3`, then opens the result at
 browser opener (`xdg-open` on Linux, `open` on macOS, `wslview` or
 `explorer.exe` on WSL).
 
-=== Prerequisites
+== Prerequisites
 
 The PlantUML Docker server must be running before using `:PumlPreview`:
 

--- a/docs/modules/ROOT/pages/cheatsheets/rest.adoc
+++ b/docs/modules/ROOT/pages/cheatsheets/rest.adoc
@@ -6,9 +6,9 @@
 
 *LocalLeader* = `,` in `.http` buffers
 
-→ Back to xref:cheatsheets/index.adoc[main cheatsheet]
+→ Back to link:index.md[main cheatsheet]
 
-=== Running Requests
+== Running Requests
 
 [cols=",,",options="header",]
 |===
@@ -19,7 +19,7 @@
 |`,e` |Normal |Select environment
 |===
 
-=== Commands Reference
+== Commands Reference
 
 [cols=",",options="header",]
 |===
@@ -33,4 +33,4 @@
 |`:Kulala search` |Search and jump to a request
 |===
 
-→ xref:guides/rest.adoc[Guide]
+→ link:../guides/rest.md[Guide]

--- a/docs/modules/ROOT/pages/cheatsheets/surround.adoc
+++ b/docs/modules/ROOT/pages/cheatsheets/surround.adoc
@@ -4,14 +4,14 @@
 
 = Surround Cheatsheet (vim-surround)
 
-→ Back to xref:cheatsheets/index.adoc[main cheatsheet]
+→ Back to link:index.md[main cheatsheet]
 
 vim-surround adds keybindings to add, change, and delete surrounding
 characters (quotes, brackets, tags, etc.) around text objects.
 
 '''''
 
-=== Change surroundings
+== Change surroundings
 
 [cols=",,",options="header",]
 |===
@@ -24,7 +24,7 @@ characters (quotes, brackets, tags, etc.) around text objects.
 |`cst"` |Change tag to `"` |`++<++q++>++hello++<++/q++>++` → `"hello"`
 |===
 
-=== Delete surroundings
+== Delete surroundings
 
 [cols=",,",options="header",]
 |===
@@ -35,7 +35,7 @@ characters (quotes, brackets, tags, etc.) around text objects.
 `hello`
 |===
 
-=== Add surroundings
+== Add surroundings
 
 Cursor must be inside (or on) the text to surround. `ys` = "`you
 surround`".
@@ -56,7 +56,7 @@ surround`".
 `++<++p++><++em++>++hello++<++/em++><++/p++>++`
 |===
 
-=== Visual mode
+== Visual mode
 
 Select text in visual mode, then press `S` followed by the surround
 character.

--- a/docs/modules/ROOT/pages/cheatsheets/unimpaired.adoc
+++ b/docs/modules/ROOT/pages/cheatsheets/unimpaired.adoc
@@ -1,17 +1,16 @@
-// :auto-generated: true
-// :source: docs/cheatsheets/unimpaired.md
-// Remove this header to take manual ownership of this file
+// Manually owned: pandoc generates broken ++{++motion} passthrough for {motion}
+// in table cells; fixed to ++{motion}++ here. Do not add auto-generated sentinel.
 
 = Unimpaired Cheatsheet (vim-unimpaired)
 
-→ Back to xref:cheatsheets/index.adoc[main cheatsheet]
+→ Back to link:index.md[main cheatsheet]
 
 vim-unimpaired provides pairs of bracket mappings — `++[++` for
 "`previous / enable`" and `++]++` for "`next / disable`".
 
 '''''
 
-=== Buffer navigation
+== Buffer navigation
 
 [cols=",",options="header",]
 |===
@@ -22,7 +21,7 @@ vim-unimpaired provides pairs of bracket mappings — `++[++` for
 |`++]++B` |Last buffer
 |===
 
-=== Quickfix / location list
+== Quickfix / location list
 
 [cols=",",options="header",]
 |===
@@ -35,7 +34,7 @@ vim-unimpaired provides pairs of bracket mappings — `++[++` for
 |`++]++l` |Next location list entry
 |===
 
-=== Argument list
+== Argument list
 
 [cols=",",options="header",]
 |===
@@ -44,7 +43,7 @@ vim-unimpaired provides pairs of bracket mappings — `++[++` for
 |`++]++a` |Next file in argument list
 |===
 
-=== Line operations
+== Line operations
 
 [cols=",",options="header",]
 |===
@@ -55,7 +54,7 @@ vim-unimpaired provides pairs of bracket mappings — `++[++` for
 |`++]++e` |Exchange current line with line below
 |===
 
-=== Option toggles
+== Option toggles
 
 Prefix with `++[++o` to enable, `++]++o` to disable, `yo` to toggle.
 
@@ -71,15 +70,15 @@ Prefix with `++[++o` to enable, `++]++o` to disable, `yo` to toggle.
 |`++[++ox` / `++]++ox` / `yox` |`cursorline` {plus} `cursorcolumn`
 |===
 
-=== URL / XML encoding
+== URL / XML encoding
 
 [cols=",",options="header",]
 |===
 |Keys |Action
-|`++[++u++{++motion}` |URL-encode text
-|`++]++u++{++motion}` |URL-decode text
-|`++[++x++{++motion}` |XML-encode text (`&amp;`, `&lt;`, etc.)
-|`++]++x++{++motion}` |XML-decode text
+|`++[++u++{motion}++` |URL-encode text
+|`++]++u++{motion}++` |URL-decode text
+|`++[++x++{motion}++` |XML-encode text (`&amp;`, `&lt;`, etc.)
+|`++]++x++{motion}++` |XML-decode text
 |===
 
 '''''

--- a/docs/modules/ROOT/pages/guides/ai-tools.adoc
+++ b/docs/modules/ROOT/pages/guides/ai-tools.adoc
@@ -22,9 +22,9 @@ Copilot chat and completions
 
 '''''
 
-=== GitHub Copilot CLI
+== GitHub Copilot CLI
 
-==== Prerequisites
+=== Prerequisites
 
 [arabic]
 . Install https://nodejs.org/[Node.js 22{plus}].
@@ -42,7 +42,7 @@ copilot
 # then enter: /login
 ----
 
-==== Usage
+=== Usage
 
 Select code in visual mode (or stay in normal mode to use the whole
 buffer), then:
@@ -62,7 +62,7 @@ to close it.
 You can also run the commands directly: - `:CopilotSuggest` — suggest -
 `:CopilotExplain` — explain
 
-==== How it works
+=== How it works
 
 `lua/config/copilot++_++cli.lua` uses `vim.system()` to invoke
 `copilot -sp "++<++prompt++>++"` non-interactively. The `-s` flag
@@ -72,17 +72,17 @@ floating window.
 
 '''''
 
-=== OpenSpec
+== OpenSpec
 
 OpenSpec is the change-management workflow tool used in this repo (see
 `openspec/` directory).
 
-==== Prerequisites
+=== Prerequisites
 
 `openspec` must be on your `$PATH`. Install it following the project’s
 own README, or check `openspec --help` to confirm it’s available.
 
-==== Usage
+=== Usage
 
 [width="100%",cols="34%,33%,33%",options="header",]
 |===
@@ -105,7 +105,7 @@ that change:
 Output is shown in a read-only bottom split (15 lines tall). Press `q`
 or `++<++Esc++>++` to close it.
 
-==== How it works
+=== How it works
 
 `lua/config/openspec.lua` uses synchronous `vim.fn.system()`
 (appropriate because `openspec` commands complete in well under a
@@ -113,7 +113,7 @@ second) and opens a scratch buffer in a `botright split`.
 
 '''''
 
-=== Serena MCP Server
+== Serena MCP Server
 
 https://github.com/oramasearch/serena[Serena] is a symbol-aware
 code-intelligence MCP (Model Context Protocol) server. When running, it
@@ -121,7 +121,7 @@ allows GitHub Copilot to perform semantic operations — go-to-definition,
 find-references, workspace symbol search — that it cannot do from text
 alone.
 
-==== Prerequisites
+=== Prerequisites
 
 Node.js 18{plus} is required. Install Serena globally to avoid `npx`
 startup latency on every request:
@@ -138,7 +138,7 @@ Or rely on on-demand `npx` (slower first call, no install needed):
 # No install needed; npx downloads on first use
 ----
 
-==== Configuration
+=== Configuration
 
 Serena is declared in `lua/plugins/copilot.lua` via
 `vim.g.copilot++_++mcp++_++servers`. No extra setup is needed — it is
@@ -147,7 +147,7 @@ auto-discovered by `copilot.vim` at startup.
 The config prefers the global `serena` binary when found on `$PATH`;
 otherwise it falls back to `npx -y @oramasearch/serena`.
 
-==== Verifying
+=== Verifying
 
 To confirm the MCP server is configured, run inside Neovim:
 
@@ -161,4 +161,4 @@ and the launch command.
 
 '''''
 
-→ link:../cheatsheets/ai-tools.adoc[Keybinding cheatsheet]
+→ link:../cheatsheets/ai-tools.md[Keybinding cheatsheet]

--- a/docs/modules/ROOT/pages/guides/architecture.adoc
+++ b/docs/modules/ROOT/pages/guides/architecture.adoc
@@ -10,7 +10,7 @@ where it is, and how the pieces fit together at startup.
 
 '''''
 
-=== Startup Order
+== Startup Order
 
 Neovim always loads files in this sequence:
 
@@ -28,7 +28,7 @@ is first needed, or by `require()` calls inside plugin config functions.
 
 '''''
 
-=== Root-Level Files
+== Root-Level Files
 
 [width="100%",cols="50%,50%",options="header",]
 |===
@@ -50,13 +50,13 @@ Copilot instructions file.
 
 '''''
 
-=== `lua/` — The Lua Source Tree
+== `lua/` — The Lua Source Tree
 
 All runtime Lua code lives here. Neovim adds `lua/` to the Lua
 `package.path` automatically, so `require("config.terminal")` maps to
 `lua/config/terminal.lua`.
 
-==== `lua/options.lua`
+=== `lua/options.lua`
 
 Sets `vim.opt.++*++` values (line numbers, tabs, scroll offset, etc.)
 and the two leader keys:
@@ -70,20 +70,20 @@ vim.g.maplocalleader = ","   -- Comma  (filetype keymaps)
 This file is loaded first so leader keys are defined before any plugin
 or keymap tries to reference them.
 
-==== `lua/keymaps.lua`
+=== `lua/keymaps.lua`
 
 Global `++<++leader++>++` keymaps that are not tied to any plugin or
 filetype. Things like window navigation, buffer management, and
 diagnostic shortcuts.
 
-==== `lua/loader/init.lua`
+=== `lua/loader/init.lua`
 
 Bootstraps https://github.com/folke/lazy.nvim[lazy.nvim] (downloads it
 if missing), then calls `lazy.setup()` with
 `++{++ import = "plugins" }`. This tells lazy.nvim to auto-import every
 file under `lua/plugins/` as a plugin spec.
 
-==== `lua/plugins/` — Plugin Specs
+=== `lua/plugins/` — Plugin Specs
 
 One file per plugin group. Each file returns a lazy.nvim spec table.
 Examples:
@@ -129,7 +129,7 @@ objects
 Plugins use `ft = ++{++ "markdown" }` (lazy-load on filetype) or
 `event = "VeryLazy"` (load after startup) to keep startup time fast.
 
-==== `lua/config/` — Non-Plugin Configuration Modules
+=== `lua/config/` — Non-Plugin Configuration Modules
 
 Reusable Lua modules that are `require()`d by plugin configs or
 ftplugins. They do not return lazy.nvim specs.
@@ -177,7 +177,7 @@ management).
 
 '''''
 
-=== `after/ftplugin/` — Filetype-Specific Overrides
+== `after/ftplugin/` — Filetype-Specific Overrides
 
 Neovim automatically sources `after/ftplugin/++<++filetype++>++.lua`
 when a buffer of that filetype is opened. This is the correct place for:
@@ -217,7 +217,7 @@ search)
 
 '''''
 
-=== `docker/` — Docker Service Definitions
+== `docker/` — Docker Service Definitions
 
 Each subdirectory is a self-contained Docker Compose service used by a
 Neovim feature. Start them independently with
@@ -246,21 +246,21 @@ PlantUML {plus} Mermaid diagram rendering)
 
 '''''
 
-=== `docs/` — User Documentation
+== `docs/` — User Documentation
 
 Human-readable reference material. Not loaded by Neovim.
 
-==== `docs/guides/`
+=== `docs/guides/`
 
 Long-form setup and usage guides, one per feature area. Start here when
 setting up a new language or feature on a fresh machine.
 
-==== `docs/cheatsheets/`
+=== `docs/cheatsheets/`
 
 Quick-reference keymap tables. `index.md` is the single-page master
 reference. Each other file covers one plugin or language area.
 
-==== `docs/jira-project-map.md`
+=== `docs/jira-project-map.md`
 
 Maps directory prefixes to Jira project keys. Used by
 `lua/config/jira.lua` to automatically select the right Jira project
@@ -268,7 +268,7 @@ when creating issues.
 
 '''''
 
-=== `scripts/` — Shell and Pandoc Scripts
+== `scripts/` — Shell and Pandoc Scripts
 
 Helper scripts invoked by Neovim commands, not intended to be run
 directly by the user.
@@ -288,7 +288,7 @@ conversion
 
 '''''
 
-=== `openspec/` — OpenSpec Change Management
+== `openspec/` — OpenSpec Change Management
 
 OpenSpec is a lightweight spec-driven workflow for tracking proposed
 changes to this configuration. It is used by the Copilot CLI and
@@ -316,7 +316,7 @@ directory.
 
 '''''
 
-=== `.github/` — Copilot CLI Integration
+== `.github/` — Copilot CLI Integration
 
 [width="100%",cols="50%,50%",options="header",]
 |===
@@ -334,7 +334,7 @@ how to invoke an OpenSpec workflow step.
 
 '''''
 
-=== `.opencode/` — opencode-ai Integration
+== `.opencode/` — opencode-ai Integration
 
 Mirror of `.github/skills/` for the opencode-ai editor assistant.
 Contains the same OpenSpec skill definitions in the format opencode-ai
@@ -342,7 +342,7 @@ expects.
 
 '''''
 
-=== `.serena/` — Serena MCP Server State
+== `.serena/` — Serena MCP Server State
 
 Runtime state for the https://github.com/oraios/serena[Serena] MCP
 server:
@@ -363,7 +363,7 @@ sessions
 
 '''''
 
-=== `testdocs/`
+== `testdocs/`
 
 Sample files used for manual testing of preview features
 (e.g. `test.puml` for verifying the PlantUML ASCII preview). Not part of

--- a/docs/modules/ROOT/pages/guides/cli-console-mode.adoc
+++ b/docs/modules/ROOT/pages/guides/cli-console-mode.adoc
@@ -9,7 +9,7 @@ is available — physical TTY, SSH sessions without X forwarding, and
 headless servers — and documents the AI research assistant that works in
 all environments.
 
-=== Console Detection
+== Console Detection
 
 The configuration detects console mode via a single boolean flag:
 
@@ -37,7 +37,7 @@ which covers:
 No manual override flag is needed. If the detection is wrong for your
 setup, file an issue.
 
-=== Clipboard — OSC 52
+== Clipboard — OSC 52
 
 In console, SSH, and TTY sessions (where `$DISPLAY` and
 `$WAYLAND++_++DISPLAY` are both unset) the config uses the *OSC 52*
@@ -46,17 +46,17 @@ required, but the host terminal must support OSC 52.
 
 See the full setup guide — terminal support matrix, tmux configuration,
 RDP notes, and paste caveats:
-*xref:guides/clipboard.adoc[docs/guides/clipboard.adoc]*
+*link:clipboard.md[docs/guides/clipboard.md]*
 
 '''''
 
-=== Markdown Preview — Glow
+== Markdown Preview — Glow
 
 In console sessions, `:MarkdownPreview` (which opens a browser) is
 replaced by https://github.com/charmbracelet/glow[glow], which renders
 Markdown with colour and tables in a floating popup window.
 
-==== Prerequisites
+=== Prerequisites
 
 Install the `glow` binary:
 
@@ -78,7 +78,7 @@ brew install glow
 Neovim will emit a `WARN` notification at preview time if `glow` is not
 found on `$PATH` — it will not crash.
 
-==== Usage
+=== Usage
 
 The preview keymap is consistent across environments:
 
@@ -91,7 +91,7 @@ The preview keymap is consistent across environments:
 
 Press `q` or `++<++Esc++>++` to close the popup.
 
-==== Closing an orphaned popup
+=== Closing an orphaned popup
 
 Occasionally the Glow popup is left open after navigating away
 (e.g. after following a link with `++<++CR++>++`). The popup is a
@@ -122,7 +122,7 @@ This closes every floating window in the current tab page (including any
 other popups, e.g. LSP hover or completion docs), so use it only as a
 last resort.
 
-==== Customising the popup
+=== Customising the popup
 
 Override the glow options in `lua/plugins/markdown.lua` to adjust the
 appearance (border style, max dimensions):
@@ -137,7 +137,7 @@ opts = {
 },
 ----
 
-=== PlantUML ASCII Preview
+== PlantUML ASCII Preview
 
 `:PumlPreviewAscii` fetches plain ASCII art from the PlantUML Docker
 server’s `/txt/` endpoint and displays it in a scratch buffer inside a
@@ -158,7 +158,7 @@ and change the endpoint in `lua/plugins/plantuml.lua` from `/txt/` back
 to `/utxt/`.
 ____
 
-==== Prerequisites
+=== Prerequisites
 
 The PlantUML Docker server must be running:
 
@@ -167,7 +167,7 @@ The PlantUML Docker server must be running:
 docker compose -f ~/.config/nvim/docker/plantuml-server/docker-compose.yml up -d
 ----
 
-==== Keymaps (plantuml buffers)
+=== Keymaps (plantuml buffers)
 
 [width="100%",cols="50%,50%",options="header",]
 |===
@@ -183,7 +183,7 @@ ____
 without opening a browser.
 ____
 
-=== Open URL Behaviour
+== Open URL Behaviour
 
 In console mode, `util.open++_++url` skips all browser-opener attempts
 and instead emits an `INFO` notification containing the full URL. Copy
@@ -194,7 +194,7 @@ In GUI mode, the existing behaviour is unchanged: `xdg-open` / `open` /
 `wslview` / `explorer.exe` are tried in order, and a `WARN` notification
 is emitted if none are found.
 
-=== AI Research — Avante
+== AI Research — Avante
 
 https://github.com/yetone/avante.nvim[avante.nvim] provides a Q&A chat
 interface inside Neovim. Two backends are available and can be switched
@@ -219,7 +219,7 @@ an unreleased commit produces a `"release not found"` error and avante
 will not load.
 ____
 
-==== Keymaps (global)
+=== Keymaps (global)
 
 [cols=",",options="header",]
 |===
@@ -229,7 +229,7 @@ ____
 |`++<++leader++>++ac` |Switch to copilot provider and open avante
 |===
 
-==== Ollama Setup
+=== Ollama Setup
 
 Ollama runs as a persistent Docker service. *Both commands below are
 required on first setup.*
@@ -267,7 +267,7 @@ Then update `model` in `lua/plugins/avante.lua`:
 model = "llama3.2:3b",
 ----
 
-===== GPU Acceleration (NVIDIA)
+==== GPU Acceleration (NVIDIA)
 
 GPU support is opt-in. Open `docker/ollama/docker-compose.yml` and
 uncomment the `deploy` block:
@@ -287,13 +287,13 @@ Requires the
 https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html[NVIDIA
 Container Toolkit].
 
-===== When ollama is unreachable
+==== When ollama is unreachable
 
 If the ollama service is not running when you submit a question, avante
 will display the HTTP error in its buffer. Neovim will not crash. Start
 the service and retry.
 
-==== Copilot Backend
+=== Copilot Backend
 
 No additional setup is required. Avante reuses the credentials already
 held by `github/copilot.vim`. If Copilot is not yet authenticated, run

--- a/docs/modules/ROOT/pages/guides/clipboard.adoc
+++ b/docs/modules/ROOT/pages/guides/clipboard.adoc
@@ -1,3 +1,7 @@
+// :auto-generated: true
+// :source: docs/guides/clipboard.md
+// Remove this header to take manual ownership of this file
+
 = Clipboard Integration Guide
 
 Neovim uses the system clipboard through a *provider* — an external tool
@@ -5,11 +9,11 @@ Neovim uses the system clipboard through a *provider* — an external tool
 clipboard. This config selects the provider automatically based on the
 environment.
 
-→ Keybinding reference: xref:cheatsheets/editing.adoc[Editing Cheatsheet]
+→ Keybinding reference: ../cheatsheets/editing.md
 
 '''''
 
-=== How the provider is chosen
+== How the provider is chosen
 
 The selection logic is in `lua/options.lua`:
 
@@ -29,9 +33,9 @@ alternative.
 
 '''''
 
-=== GUI Linux — X11
+== GUI Linux — X11
 
-==== Tool: xclip or xsel
+=== Tool: xclip or xsel
 
 Neovim checks for `xclip` first, then `xsel`. Install one of them:
 
@@ -50,7 +54,7 @@ sudo dnf install xclip
 sudo pacman -S xclip
 ----
 
-==== Verify
+=== Verify
 
 Open Neovim and run:
 
@@ -76,7 +80,7 @@ echo "hello" | xclip -selection clipboard
 # then in Neovim: <leader>p  — should paste "hello"
 ----
 
-==== Troubleshooting
+=== Troubleshooting
 
 [width="100%",cols="50%,50%",options="header",]
 |===
@@ -94,9 +98,9 @@ tmux intercepts OSC 52 by default
 
 '''''
 
-=== GUI Linux — Wayland
+== GUI Linux — Wayland
 
-==== Tool: wl-clipboard
+=== Tool: wl-clipboard
 
 [source,sh]
 ----
@@ -113,7 +117,7 @@ sudo pacman -S wl-clipboard
 `wl-clipboard` provides two binaries: `wl-copy` and `wl-paste`. Neovim
 detects them automatically when `$WAYLAND++_++DISPLAY` is set.
 
-==== Verify
+=== Verify
 
 [source,sh]
 ----
@@ -123,7 +127,7 @@ wl-paste          # should print: hello
 
 Then in Neovim `++<++leader++>++p` should paste "`hello`".
 
-==== Wayland {plus} X11 compatibility (XWayland)
+=== Wayland {plus} X11 compatibility (XWayland)
 
 If you start Neovim from an XWayland application (e.g. a legacy X11
 terminal inside a Wayland session), `$DISPLAY` may be set but
@@ -136,15 +140,15 @@ Ghostty) so that `$WAYLAND++_++DISPLAY` is inherited.
 
 '''''
 
-=== WSL (Windows Subsystem for Linux)
+== WSL (Windows Subsystem for Linux)
 
-==== Tool: win32yank.exe
+=== Tool: win32yank.exe
 
 `win32yank.exe` is a small Windows utility that reads and writes the
 Windows clipboard. Because it runs as a Windows `.exe`, it is accessible
 from WSL without X11 forwarding.
 
-===== Install on the Windows side
+==== Install on the Windows side
 
 Open a *Windows* PowerShell or Command Prompt (not a WSL shell):
 
@@ -161,7 +165,7 @@ choco install win32yank
 # Place it anywhere on your Windows PATH, e.g. C:\Windows\System32\
 ----
 
-===== Make it visible from WSL
+==== Make it visible from WSL
 
 WSL inherits the Windows `PATH` by default (controlled by
 `appendWindowsPath = true` in `/etc/wsl.conf`). No extra steps are
@@ -181,14 +185,14 @@ to your shell’s `$PATH` in `~/.bashrc` / `~/.zshrc`:
 export PATH="$PATH:/mnt/c/path/to/win32yank/directory"
 ----
 
-===== How the config uses it
+==== How the config uses it
 
 When `WSL++_++DISTRO++_++NAME` is set and `win32yank.exe` is on `$PATH`,
 the config registers it as a custom `vim.g.clipboard` provider that
 handles both `{plus}` and `++*++` registers. The `--crlf` / `--lf` flags
 handle the Windows line-ending difference automatically.
 
-===== Verify
+==== Verify
 
 [source,sh]
 ----
@@ -207,9 +211,9 @@ ____
 
 '''''
 
-=== SSH / TTY / Console — OSC 52
+== SSH / TTY / Console — OSC 52
 
-==== No external tool required
+=== No external tool required
 
 When Neovim detects no graphical display (`$DISPLAY` and
 `$WAYLAND++_++DISPLAY` are both unset), it uses the *OSC 52* terminal
@@ -224,7 +228,7 @@ forwarding or any tool on the remote server.
 *Minimum requirement:* Neovim ≥ 0.10 (the built-in
 `vim.ui.clipboard.osc52` module).
 
-==== Terminal support matrix
+=== Terminal support matrix
 
 [width="100%",cols="25%,25%,25%,25%",options="header",]
 |===
@@ -246,7 +250,7 @@ You have two options: - Connect from a terminal that does support it
 `xclip`/`xsel` installed on the server
 ____
 
-==== Paste over SSH
+=== Paste over SSH
 
 Most terminals block OSC 52 paste for security (to prevent a remote host
 from reading your clipboard). If `++<++leader++>++p` does not work in an
@@ -263,7 +267,7 @@ local clipboard:
 |Most Linux terminals |`Shift{plus}Insert`
 |===
 
-==== tmux inside SSH
+=== tmux inside SSH
 
 tmux intercepts OSC 52 by default and does not forward it to the outer
 terminal. To enable clipboard pass-through, add this to `~/.tmux.conf`:
@@ -278,7 +282,7 @@ Then reload: `tmux source ~/.tmux.conf`.
 With `set-clipboard on`, tmux forwards OSC 52 to the outer terminal,
 which then writes to the local clipboard.
 
-==== RDP sessions
+=== RDP sessions
 
 RDP clipboard is a separate channel from the terminal clipboard. OSC 52
 works if the RDP client renders a terminal that supports it
@@ -287,7 +291,7 @@ machine). On Linux desktops inside RDP (e.g. xrdp {plus} GNOME), you are
 back in a graphical session so `$DISPLAY` is set — the config will use
 `xclip`/`xsel` automatically.
 
-==== Verify OSC 52 is working
+=== Verify OSC 52 is working
 
 In an SSH session, run:
 
@@ -302,9 +306,9 @@ and press `++<++leader++>++y`. Switch to a local application and paste.
 
 '''''
 
-=== Troubleshooting
+== Troubleshooting
 
-==== `:checkhealth clipboard`
+=== `:checkhealth clipboard`
 
 Always start here. Run `:checkhealth` in Neovim and read the `clipboard`
 section:
@@ -321,7 +325,7 @@ If the provider shows as `OSC 52` there will be no checkhealth entry —
 OSC 52 is transparent to Neovim’s health check system. Verify it
 empirically (see above).
 
-==== Common issues
+=== Common issues
 
 [width="100%",cols="34%,33%,33%",options="header",]
 |===

--- a/docs/modules/ROOT/pages/guides/confluence.adoc
+++ b/docs/modules/ROOT/pages/guides/confluence.adoc
@@ -15,7 +15,7 @@ required.
 
 '''''
 
-=== Prerequisites
+== Prerequisites
 
 ____
 *Required:* `pandoc`, `curl`, and `jq` must be installed before `,cc`
@@ -45,19 +45,19 @@ link:#authentication[Authentication]
 
 '''''
 
-=== Authentication
+== Authentication
 
 The publisher reads credentials from environment variables. They are
 never stored in any file.
 
-==== Generating an API token
+=== Generating an API token
 
 [arabic]
 . Go to https://id.atlassian.com/manage-profile/security/api-tokens
 . Click *Create API token*
 . Give it a label (e.g. `nvim-confluence-publish`) and copy the token
 
-==== Setting the environment variables
+=== Setting the environment variables
 
 Add these lines to your shell profile (`~/.bashrc`, `~/.zshrc`, or
 `~/.profile`):
@@ -79,7 +79,7 @@ ____
 
 '''''
 
-=== Page map
+== Page map
 
 The publisher resolves which Confluence page to update by reading
 `docs/confluence-page-map.md` at the root of the git repository
@@ -98,11 +98,11 @@ and does nothing.
 
 '''''
 
-=== Usage
+== Usage
 
 Open any markdown file that is listed in the page map, then:
 
-==== Publishing
+=== Publishing
 
 [cols=",",options="header",]
 |===
@@ -114,7 +114,7 @@ Open any markdown file that is listed in the page map, then:
 Progress messages appear in the notification area. The final message
 includes the published page URL.
 
-==== Pulling from Confluence
+=== Pulling from Confluence
 
 [width="100%",cols="50%,50%",options="header",]
 |===
@@ -127,7 +127,7 @@ The local file is overwritten with the Confluence content (converted
 back to Markdown via pandoc). A `.bak` backup of the previous local file
 is created automatically before overwriting.
 
-==== Fetching comments
+=== Fetching comments
 
 [cols=",",options="header",]
 |===
@@ -141,7 +141,7 @@ directory as the source file. Existing comment files are overwritten.
 
 '''''
 
-=== Conflict detection
+== Conflict detection
 
 The publisher tracks the last-published Confluence page version in
 `docs/.confluence-state.json` (relative to the git root). When you run
@@ -155,7 +155,7 @@ team benefits from conflict detection.
 
 '''''
 
-=== Link substitution and code macros
+== Link substitution and code macros
 
 When `confluence++_++filter.lua` is found (either alongside the publish
 script or via `CONFLUENCE++_++FILTER++_++LUA`), `,cc` automatically:
@@ -181,7 +181,7 @@ export CONFLUENCE_FILTER_LUA="/home/walt/src/rmv/drive-api/scripts/confluence_fi
 
 '''''
 
-=== Troubleshooting
+== Troubleshooting
 
 [width="100%",cols="34%,33%,33%",options="header",]
 |===

--- a/docs/modules/ROOT/pages/guides/diagrams.adoc
+++ b/docs/modules/ROOT/pages/guides/diagrams.adoc
@@ -34,7 +34,7 @@ provide syntax highlighting and text objects for both file types.
 https://github.com/artempyanykh/marksman[marksman] LSP is configured for
 Markdown, providing cross-file link completion and diagnostics.
 
-=== Prerequisites
+== Prerequisites
 
 [width="100%",cols="34%,33%,33%",options="header",]
 |===
@@ -54,7 +54,7 @@ most Linux distros
 |*marksman* _(optional)_ |Markdown LSP |`sudo apt install marksman`
 |===
 
-==== Installing Node.js via nvm
+=== Installing Node.js via nvm
 
 Using https://github.com/nvm-sh/nvm[nvm] installs the LTS release into a
 user-managed prefix — no `sudo` needed for global packages:
@@ -83,7 +83,7 @@ ____
 *WSL note:* nvm works identically on WSL — no extra steps required.
 ____
 
-=== Starting the PlantUML Server
+== Starting the PlantUML Server
 
 A Docker Compose file is provided at
 `docker/plantuml-server/docker-compose.yml` using the
@@ -102,9 +102,9 @@ docker compose -f ~/.config/nvim/docker/plantuml-server/docker-compose.yml down
 The server is stateless — no build step or volume is needed. It will be
 available at `http://localhost:8080` immediately after startup.
 
-=== Quick Start
+== Quick Start
 
-==== Markdown with embedded Mermaid
+=== Markdown with embedded Mermaid
 
 Mermaid diagrams are rendered directly by the browser preview — no
 Docker server or extra plugin is required.
@@ -134,7 +134,7 @@ graph TD
 . Press *`,p`* to open a live browser preview. The Mermaid diagram
 renders automatically.
 
-==== Markdown with embedded PlantUML
+=== Markdown with embedded PlantUML
 
 [arabic]
 . Start the PlantUML server (if not already running):
@@ -168,7 +168,7 @@ WebApp --> User : HTTP response
 . Press *`,p`* to open a live browser preview. The preview
 auto-refreshes as you edit.
 
-==== Standalone `.puml` files
+=== Standalone `.puml` files
 
 [arabic]
 . Ensure the PlantUML server is running (see
@@ -191,12 +191,12 @@ Bob --> Alice : Hi there
 . Press *`,p`* to render and open the diagram in your browser via the
 Docker server.
 
-=== Exporting to PDF
+== Exporting to PDF
 
 The `:MdToPdf` command exports the current Markdown document to PDF,
 rendering all fenced `plantuml` and `mermaid` code blocks as PNG images.
 
-==== Prerequisites
+=== Prerequisites
 
 [width="100%",cols="50%,50%",options="header",]
 |===
@@ -226,7 +226,7 @@ the top of `docker/md2pdf/mermaid-filter.lua` to point at your own
 instance.
 ____
 
-==== Usage
+=== Usage
 
 [arabic]
 . Ensure the PlantUML server is running (see
@@ -242,7 +242,7 @@ nvim architecture.md
 The output file is written to the same directory as the source file with
 a `.pdf` extension (e.g. `architecture.pdf`).
 
-==== How It Works
+=== How It Works
 
 The command runs `pandoc/extra` via `docker run --rm --network=host`.
 Two bundled Pandoc Lua filters process diagram blocks before PDF
@@ -267,7 +267,7 @@ fenced plantuml block                  fenced mermaid block
   → embedded as image in PDF             → embedded as image in PDF
 ....
 
-=== Keybindings
+== Keybindings
 
 `localleader` is *`,`* for both `markdown` and `plantuml` buffers.
 
@@ -285,7 +285,7 @@ fenced plantuml block                  fenced mermaid block
 (`PumlPreviewAscii`)
 |===
 
-=== How PumlPreview Works
+== How PumlPreview Works
 
 The `:PumlPreview` command (defined in `lua/plugins/plantuml.lua`) reads
 the current buffer, encodes it using PlantUML’s deflate {plus} base64
@@ -300,7 +300,7 @@ on Linux, `open` on macOS, `wslview` or `explorer.exe` on WSL). The
 Docker server renders the diagram and serves it as a PNG directly in
 your browser.
 
-=== Configuration
+== Configuration
 
 The PlantUML server URL is hardcoded to `http://localhost:8080`. To
 change it, update these two locations:
@@ -320,19 +320,19 @@ The Mermaid PDF export endpoint defaults to the Kroki public API
 `KROKI++_++BASE++_++URL` at the top of
 `docker/md2pdf/mermaid-filter.lua`.
 
-=== LSP (marksman)
+== LSP (marksman)
 
 The `marksman` LSP server provides: - *Link completion* — auto-complete
 `++[++text++]++(path)` links to other files - *Diagnostics* — broken
 links and malformed references are flagged inline - *Go-to-definition*
 (`gd`) — jump to linked documents
 
-See xref:index.adoc#lsp-support[readme.adoc] for the shared LSP
+See link:../../readme.md#lsp-support[readme.md] for the shared LSP
 keybindings.
 
-=== Diagram Types Supported
+== Diagram Types Supported
 
-==== PlantUML
+=== PlantUML
 
 PlantUML supports a wide range of diagram types in both workflows:
 
@@ -351,7 +351,7 @@ PlantUML supports a wide range of diagram types in both workflows:
 |C4 |`@startuml` with `!include C4++_++Context.puml`
 |===
 
-==== Mermaid
+=== Mermaid
 
 Mermaid covers a complementary set of diagram types, all rendered with a
 `mermaid` fence in Markdown:

--- a/docs/modules/ROOT/pages/guides/dotnet.adoc
+++ b/docs/modules/ROOT/pages/guides/dotnet.adoc
@@ -7,11 +7,11 @@
 Full C++#++ editing support: syntax highlighting, LSP (Roslyn),
 formatting (CSharpier), and an interactive REPL (csharprepl via
 iron.nvim). F++#++ support is unchanged — see
-xref:guides/fsharp.adoc[docs/guides/fsharp.adoc].
+link:fsharp.md[docs/guides/fsharp.md].
 
 '''''
 
-=== Prerequisites
+== Prerequisites
 
 Install the following .NET global tools:
 
@@ -21,7 +21,7 @@ dotnet tool install -g csharpier    # Formatter
 dotnet tool install -g csharprepl   # Interactive REPL
 ----
 
-==== Neovim Version Requirement
+=== Neovim Version Requirement
 
 ____
 *roslyn.nvim requires Neovim ≥ 0.12.* Run `nvim --version` to check. If
@@ -29,7 +29,7 @@ you are on an older version, see link:#upgrading-neovim[Upgrading
 Neovim] below before proceeding.
 ____
 
-==== Installing the Roslyn Language Server
+=== Installing the Roslyn Language Server
 
 The Roslyn LSP is the official Microsoft C++#++ language server used in
 VS Code’s C++#++ Dev Kit. It is *not* installed via
@@ -77,7 +77,7 @@ for some versions, which will cause `unzip` to fail with "`not a zip
 file`".
 ____
 
-==== Upgrading Neovim
+=== Upgrading Neovim
 
 The system package manager (`apt`, `dnf`, etc.) and Snap often lag well
 behind the latest Neovim release. *Use the AppImage or tarball methods
@@ -121,7 +121,7 @@ ____
 
 '''''
 
-=== Quick Start
+== Quick Start
 
 [arabic]
 . Open any `.cs` file — Roslyn attaches automatically.
@@ -132,7 +132,7 @@ iron.nvim’s `:IronRepl`.
 
 '''''
 
-=== LSP Features (Roslyn)
+== LSP Features (Roslyn)
 
 All standard LSP keybindings apply in `.cs` buffers:
 
@@ -166,7 +166,7 @@ opts if your `.sln` lives above the project root.
 
 '''''
 
-=== C++#++ REPL (csharprepl via iron.nvim)
+== C++#++ REPL (csharprepl via iron.nvim)
 
 LocalLeader is `,` in `.cs` buffers.
 
@@ -188,7 +188,7 @@ window.
 
 '''''
 
-=== Formatting (CSharpier)
+== Formatting (CSharpier)
 
 Format-on-save is enabled automatically in `.cs` buffers via
 `conform.nvim`. Manual trigger:
@@ -204,7 +204,7 @@ configuration file required.
 
 '''''
 
-=== Typical Workflow
+== Typical Workflow
 
 ....
  ┌──────────────────────────────────────────────────────┐

--- a/docs/modules/ROOT/pages/guides/fsharp.adoc
+++ b/docs/modules/ROOT/pages/guides/fsharp.adoc
@@ -11,7 +11,7 @@ go-to-definition, hover docs, and formatting.
 All F++#++ plugins lazy-load only when you open a `.fs`, `.fsx`, or
 `.fsi` file.
 
-=== Prerequisites
+== Prerequisites
 
 [width="100%",cols="34%,33%,33%",options="header",]
 |===
@@ -23,7 +23,7 @@ All F++#++ plugins lazy-load only when you open a `.fs`, `.fsx`, or
 |`dotnet tool install -g fsautocomplete`
 |===
 
-==== Installing .NET SDK
+=== Installing .NET SDK
 
 Follow the official guide for Ubuntu/WSL:
 
@@ -37,14 +37,14 @@ sudo apt update && sudo apt install -y dotnet-sdk-8.0
 
 Or download directly from https://dotnet.microsoft.com/download.
 
-=== LSP
+== LSP
 
 The `fsautocomplete` server is configured in `lua/config/lsp.lua`. See
 the link:#prerequisites[Prerequisites] section above for install steps
-and xref:index.adoc#lsp-support[readme.adoc] for the shared LSP
+and link:../../readme.md#lsp-support[readme.md] for the shared LSP
 keybindings.
 
-=== Quick Start
+== Quick Start
 
 [arabic]
 . *Verify prerequisites are installed:*
@@ -86,7 +86,7 @@ height).
 fsautocomplete formatter. You can also trigger it manually with
 `++<++leader++>++f`.
 
-=== Typical Workflow
+== Typical Workflow
 
 ....
  ┌──────────────────────────────────────────────────────┐

--- a/docs/modules/ROOT/pages/guides/haskell.adoc
+++ b/docs/modules/ROOT/pages/guides/haskell.adoc
@@ -11,7 +11,7 @@ plugin.
 
 All Haskell plugins lazy-load only when you open a `.hs` or `.lhs` file.
 
-=== Prerequisites
+== Prerequisites
 
 [width="100%",cols="34%,33%,33%",options="header",]
 |===
@@ -22,14 +22,14 @@ All Haskell plugins lazy-load only when you open a `.hs` or `.lhs` file.
 |*haskell-language-server* |LSP server |`ghcup install hls`
 |===
 
-=== LSP
+== LSP
 
 `haskell-tools` manages the `hls` LSP connection automatically — no
 manual `lspconfig` setup is needed. See
-xref:index.adoc#lsp-support[readme.adoc] for the shared LSP
+link:../../readme.md#lsp-support[readme.md] for the shared LSP
 keybindings (`gd`, `K`, `gr`, etc.).
 
-=== REPL (GHCi)
+== REPL (GHCi)
 
 haskell-tools provides a built-in GHCi REPL. Keybindings are defined in
 `after/ftplugin/haskell.lua`.
@@ -47,7 +47,7 @@ Leader is `Space`; no LocalLeader bindings are used in Haskell buffers.
 |`Space-ea` |Evaluate all code snippets in the buffer
 |===
 
-=== Configuration
+== Configuration
 
 Plugin spec lives in `lua/plugins/haskell.lua` and ftplugin overrides
 live in `after/ftplugin/haskell.lua`.

--- a/docs/modules/ROOT/pages/guides/janet.adoc
+++ b/docs/modules/ROOT/pages/guides/janet.adoc
@@ -33,9 +33,9 @@ for Janet and provides *format-on-save* as well as a manual
 *`++<++leader++>++f`* keybinding (normal and visual mode) to reformat
 the current buffer or selection.
 
-=== Prerequisites
+== Prerequisites
 
-==== Installing Janet
+=== Installing Janet
 
 [width="100%",cols="50%,50%",options="header",]
 |===
@@ -57,7 +57,7 @@ Verify the installation:
 janet -v
 ----
 
-==== Installing jpm (Janet Package Manager)
+=== Installing jpm (Janet Package Manager)
 
 `jpm` is required to install the LSP server and manage Janet projects.
 It is typically bundled with Janet installations. If it is not
@@ -73,7 +73,7 @@ janet bootstrap.janet
 See https://github.com/janet-lang/jpm[janet-lang/jpm] for full
 instructions.
 
-=== LSP
+== LSP
 
 The `janet++_++lsp` server is configured in `lua/config/lsp.lua`.
 Install it via jpm:
@@ -84,10 +84,10 @@ jpm install janet-lsp
 ----
 
 Make sure `janet-lsp` is on your `$PATH` (typically `~/.jpm/bin/`). See
-xref:index.adoc#lsp-support[readme.adoc] for the shared LSP
+link:../../readme.md#lsp-support[readme.md] for the shared LSP
 keybindings.
 
-=== Quick Start
+== Quick Start
 
 [arabic]
 . *Open a Janet source file* — plugins load automatically:
@@ -132,7 +132,7 @@ evaluate code in a `.janet` buffer — no manual server setup is needed.
 . *Parinfer* runs in the background — just adjust indentation and parens
 follow. No keys needed.
 
-=== Typical Workflow
+== Typical Workflow
 
 ....
  ┌──────────────────────────────────────────────┐
@@ -160,9 +160,9 @@ S-expressions without counting parentheses.
 indentation.
 . Rainbow delimiters let you visually match nesting depth.
 
-=== Troubleshooting
+== Troubleshooting
 
-==== Conjure does not start the REPL
+=== Conjure does not start the REPL
 
 Make sure `janet` is on your `$PATH`:
 
@@ -174,7 +174,7 @@ which janet
 If Janet is installed but Neovim cannot find it, check your shell `PATH`
 and ensure it is inherited by Neovim.
 
-==== LSP features not working
+=== LSP features not working
 
 Verify `janet-lsp` is installed and accessible:
 

--- a/docs/modules/ROOT/pages/guides/jira.adoc
+++ b/docs/modules/ROOT/pages/guides/jira.adoc
@@ -6,10 +6,10 @@
 
 Create Jira issues and stories without leaving Neovim. The Jira
 integration follows the same pattern as the
-xref:guides/confluence.adoc[Confluence integration]: pure Lua, async `curl`
+link:confluence.md[Confluence integration]: pure Lua, async `curl`
 calls, and localleader keymaps in Markdown buffers.
 
-=== Prerequisites
+== Prerequisites
 
 [width="100%",cols="50%,50%",options="header",]
 |===
@@ -25,7 +25,7 @@ e.g. `https://yourcompany.atlassian.net`
 |`curl` |Already required by the Confluence integration
 |===
 
-==== Setting environment variables
+=== Setting environment variables
 
 Add to your shell profile (`~/.bashrc`, `~/.zshrc`, etc.):
 
@@ -38,13 +38,13 @@ export JIRA_BASE_URL="https://yourcompany.atlassian.net"
 
 Then reload your shell or open a new terminal before launching Neovim.
 
-=== Project Map
+== Project Map
 
 `docs/jira-project-map.md` (at the git root of your project) maps local
 path prefixes to Jira project keys. The integration reads this file each
 time a command runs.
 
-==== Format
+=== Format
 
 [source,markdown]
 ----
@@ -62,7 +62,7 @@ time a command runs.
 * The `docs/jira-project-map.md` file must exist; copy from this repo’s
 template and update the rows for your projects.
 
-=== Keymaps
+== Keymaps
 
 Keymaps are active in *Markdown buffers* only (`LocalLeader` = `,`).
 
@@ -81,9 +81,9 @@ create Task
 create Story
 |===
 
-=== Workflow
+== Workflow
 
-==== Normal mode (no pre-filled description)
+=== Normal mode (no pre-filled description)
 
 [arabic]
 . Open any markdown file whose path matches a row in
@@ -95,7 +95,7 @@ blank to skip).
 . A success notification shows the new issue key (e.g. `PROJ-42`) and
 its URL.
 
-==== Visual mode (use selection as description)
+=== Visual mode (use selection as description)
 
 [arabic]
 . Select the relevant text in visual mode.
@@ -104,7 +104,7 @@ its URL.
 from selection).
 . Success notification appears as above.
 
-=== Commands
+== Commands
 
 Both commands are also available directly:
 
@@ -122,7 +122,7 @@ description)
 description)
 |===
 
-=== Troubleshooting
+== Troubleshooting
 
 [width="100%",cols="50%,50%",options="header",]
 |===

--- a/docs/modules/ROOT/pages/guides/lisp.adoc
+++ b/docs/modules/ROOT/pages/guides/lisp.adoc
@@ -37,9 +37,9 @@ for these filetypes and provides *format-on-save* as well as a manual
 *`++<++leader++>++f`* keybinding (normal and visual mode) to reformat
 the current buffer or selection.
 
-=== Prerequisites
+== Prerequisites
 
-==== Choosing a REPL
+=== Choosing a REPL
 
 [width="100%",cols="34%,33%,33%",options="header",]
 |===
@@ -54,13 +54,13 @@ Start)
 |Fennel |Fennel REPL |`fennel --repl`
 |===
 
-=== LSP
+== LSP
 
 No Common Lisp LSP is configured by default in this repository. See
-xref:index.adoc#lsp-support[readme.adoc] for shared LSP keybindings
+link:../../readme.md#lsp-support[readme.md] for shared LSP keybindings
 that apply in buffers where an LSP client is attached.
 
-=== Quick Start
+== Quick Start
 
 [arabic]
 . *Start your REPL* in a terminal (Conjure connects to it):
@@ -190,7 +190,7 @@ form at the REPL prompt, or quit the process entirely:
 (quit)
 ----
 
-=== Structural Editing: Slurp & Barf
+== Structural Editing: Slurp & Barf
 
 Slurp and barf let you *reshape S-expressions without manually counting
 or moving parentheses*. The cursor can be anywhere inside (or on the
@@ -200,7 +200,7 @@ Each example below shows the code before and after the operation.
 
 '''''
 
-==== Slurp forward — `++>++)`
+=== Slurp forward — `++>++)`
 
 Moves the *closing* `)` one step to the right, pulling the *next
 sibling* element into the form.
@@ -220,7 +220,7 @@ on.
 
 '''''
 
-==== Barf forward — `++<++)`
+=== Barf forward — `++<++)`
 
 Moves the *closing* `)` one step to the left, pushing the *last element*
 out of the form.
@@ -239,7 +239,7 @@ accidentally slurped in, or to split a call up.
 
 '''''
 
-==== Slurp backward — `++<++(`
+=== Slurp backward — `++<++(`
 
 Moves the *opening* `(` one step to the left, pulling the *previous
 sibling* element into the form.
@@ -255,7 +255,7 @@ foo (bar baz)
 
 '''''
 
-==== Barf backward — `++>++(`
+=== Barf backward — `++>++(`
 
 Moves the *opening* `(` one step to the right, pushing the *first
 element* out of the form.
@@ -271,7 +271,7 @@ foo (bar baz)
 
 '''''
 
-==== Combining operations
+=== Combining operations
 
 Slurp/barf pairs let you migrate elements between adjacent forms without
 cutting and pasting:
@@ -286,7 +286,7 @@ cutting and pasting:
   (format t "Hello ~a!" name))
 ----
 
-=== Typical Workflow
+== Typical Workflow
 
 ....
  ┌──────────────────────────────────────────────┐
@@ -320,9 +320,9 @@ S-expressions without counting parentheses.
 indentation.
 . Rainbow delimiters let you visually match nesting depth.
 
-=== Troubleshooting
+== Troubleshooting
 
-==== HUD shows nothing / `close-connection: end of file`
+=== HUD shows nothing / `close-connection: end of file`
 
 There are *three distinct failure modes*. Read all three before
 rebuilding.
@@ -423,7 +423,7 @@ healthy, reconnect manually if you already have a `.lisp` buffer open:
 |`,cc` |Connect (or reconnect) to Swank
 |===
 
-==== Checking the full evaluation log
+=== Checking the full evaluation log
 
 The HUD shows the last few lines of Conjure’s log buffer as a floating
 popup. To see the complete history:

--- a/docs/modules/ROOT/pages/guides/markdown.adoc
+++ b/docs/modules/ROOT/pages/guides/markdown.adoc
@@ -19,16 +19,16 @@ For MARP presentation slides, see *presentations.md*.
 
 '''''
 
-=== Quick Start
+== Quick Start
 
-==== Single-file preview (no Docker required)
+=== Single-file preview (no Docker required)
 
 [arabic]
 . Open any `.md` file in Neovim.
 . Press `,p` to toggle the live browser preview.
 . Edit; the preview auto-refreshes in the browser.
 
-==== Project-wide preview with cross-page links (requires Docker)
+=== Project-wide preview with cross-page links (requires Docker)
 
 [arabic]
 . Start the markserv container from your markdown project root:
@@ -58,7 +58,7 @@ because the whole project directory is served.
 
 '''''
 
-=== PlantUML Server
+== PlantUML Server
 
 The markserv preview server generates `++<++img++>++` URLs pointing at
 `http://localhost:8080` for `plantuml` fenced blocks. The browser loads
@@ -75,7 +75,7 @@ running permanently. See diagrams.md for the full guide.
 
 '''''
 
-=== markdown-preview.nvim (`,p`)
+== markdown-preview.nvim (`,p`)
 
 `markdown-preview.nvim` opens a single-file browser preview that syncs
 with your cursor position. It renders:
@@ -86,7 +86,7 @@ needed
 * *PlantUML* fenced code blocks via the PlantUML Docker server on
 `localhost:8080`
 
-==== Limitation — cross-page links
+=== Limitation — cross-page links
 
 `markdown-preview.nvim` runs a minimal WebSocket server that serves
 *only the current buffer*. Clicking a relative link such as
@@ -99,7 +99,7 @@ between files in the editor.
 
 '''''
 
-=== Markserv Docker Server (`,sp`)
+== Markserv Docker Server (`,sp`)
 
 The markserv preview server is a custom Node.js server that renders a
 whole directory tree. Each `.md` file is rendered as GitHub-flavoured
@@ -115,7 +115,7 @@ link:#plantuml-server[Starting the PlantUML Server].
 * *`mermaid`* fenced blocks are rendered client-side by Mermaid.js
 loaded from the jsDelivr CDN — no extra server is needed.
 
-==== How it works
+=== How it works
 
 ....
 your project/
@@ -130,7 +130,7 @@ container mounts that directory at `/docs` and serves it. Visiting
 `++[++guide++]++(guide.md)` navigates to
 `http://localhost:8090/guide.md` — which the server renders correctly.
 
-==== Ports
+=== Ports
 
 [width="100%",cols="40%,60%",options="header",]
 |===
@@ -139,7 +139,7 @@ container mounts that directory at `/docs` and serves it. Visiting
 `/++__++livereload`)
 |===
 
-==== Start / stop commands
+=== Start / stop commands
 
 [source,sh]
 ----
@@ -164,7 +164,7 @@ ____
 
 '''''
 
-=== In-editor Navigation — mkdnflow.nvim
+== In-editor Navigation — mkdnflow.nvim
 
 `mkdnflow.nvim` provides in-editor link following so you can navigate
 between markdown files without leaving Neovim.
@@ -187,14 +187,18 @@ the single-file preview, or `,sp` to open it in the markserv server.
 
 '''''
 
-=== Keybindings Summary
+== Keybindings Summary
 
 LocalLeader is `,` in Markdown buffers.
 
 [width="100%",cols="43%,57%",options="header",]
 |===
 |Keys |Action
-|`,p` |Toggle `markdown-preview.nvim` single-file browser preview
+|`,p` |Toggle `markdown-preview.nvim` single-file browser preview (GUI)
+or glow popup (console)
+
+|`,pp` |Force glow popup preview — always in-terminal, regardless of
+environment
 
 |`,sp` |Open current file in markserv Docker server preview
 (`MdServerPreview`)
@@ -220,16 +224,19 @@ navigation)
 |`,md` |Export MARP slide to PDF
 |===
 
-→ link:../cheatsheets/markdown.adoc[Full cheatsheet]
+→ link:../cheatsheets/markdown.md[Full cheatsheet]
 
 '''''
 
-=== Choosing the Right Preview Tool
+== Choosing the Right Preview Tool
 
 [width="100%",cols="40%,60%",options="header",]
 |===
 |Situation |Recommended tool
 |Single file, diagrams, cursor sync |`,p` — markdown-preview.nvim
+
+|Full-screen terminal, no browser context |`,pp` — glow popup (always
+in-terminal)
 
 |Multi-file project, cross-page links, diagrams |`,sp` — markserv Docker
 server

--- a/docs/modules/ROOT/pages/guides/presentations.adoc
+++ b/docs/modules/ROOT/pages/guides/presentations.adoc
@@ -24,7 +24,7 @@ install required.
 |Export to PDF |`docker run` with `--pdf` flag
 |===
 
-=== Prerequisites
+== Prerequisites
 
 [width="100%",cols="34%,33%,33%",options="header",]
 |===
@@ -36,7 +36,7 @@ install required.
 Linux desktops
 |===
 
-=== Starting the MARP Preview Server
+== Starting the MARP Preview Server
 
 A Docker Compose file is provided at `docker/marp/docker-compose.yml`
 using the `marpteam/marp-cli` image. Port 8880 is bound to localhost
@@ -56,7 +56,7 @@ docker compose -f ~/.config/nvim/docker/marp/docker-compose.yml down
 
 The server watches for file changes and refreshes automatically.
 
-=== Quick Start
+== Quick Start
 
 [arabic]
 . Start the MARP preview server (if not already running):
@@ -103,7 +103,7 @@ Content alongside an image.
 . Press *`,mp`* to open the live preview in your browser.
 . Press *`,mx`* to export the file to PowerPoint (`.pptx`).
 
-=== Keybindings
+== Keybindings
 
 `localleader` is *`,`* in markdown buffers.
 
@@ -117,7 +117,7 @@ Content alongside an image.
 |`,p` |Toggle standard Markdown preview (`MarkdownPreviewToggle`)
 |===
 
-=== User Commands
+== User Commands
 
 The following commands are available in any markdown buffer:
 
@@ -130,16 +130,16 @@ The following commands are available in any markdown buffer:
 |`:MarpToPdf` |Convert the current file to PDF
 |===
 
-=== How It Works
+== How It Works
 
-==== Live preview (`:MarpPreview`)
+=== Live preview (`:MarpPreview`)
 
 The Docker Compose service starts `marp-cli` in server mode (`-s .`),
 which serves all Markdown files in the mounted directory as rendered
 slide decks at `http://localhost:8880/++<++filename++>++`. The
 `:MarpPreview` command opens this URL with `xdg-open`.
 
-==== Export (`:MarpToPptx`, `:MarpToHtml`, `:MarpToPdf`)
+=== Export (`:MarpToPptx`, `:MarpToHtml`, `:MarpToPdf`)
 
 Each export command runs a one-shot Docker container:
 
@@ -154,7 +154,7 @@ The output file is written to the same directory as the source file. The
 `MARP++_++USER` environment variable ensures correct file ownership on
 Linux.
 
-=== Configuration
+== Configuration
 
 The MARP server port is set to *8880* (to avoid conflict with the
 PlantUML server on 8080). To change it, update:
@@ -166,7 +166,7 @@ PlantUML server on 8080). To change it, update:
 |`lua/config/marp.lua` |URL in the `preview` function
 |===
 
-=== MARP Markdown Syntax
+== MARP Markdown Syntax
 
 MARP extends standard Markdown with presentation-specific features:
 

--- a/docs/modules/ROOT/pages/guides/rest.adoc
+++ b/docs/modules/ROOT/pages/guides/rest.adoc
@@ -8,7 +8,7 @@ https://github.com/mistweaverco/kulala.nvim[kulala.nvim] is a
 fully-featured, pure-Lua REST client for Neovim. Write your API requests
 in `.http` files and execute them directly from the editor.
 
-=== Prerequisites
+== Prerequisites
 
 [width="100%",cols="34%,33%,33%",options="header",]
 |===
@@ -22,7 +22,7 @@ https://github.com/neovim/neovim/releases[github.com/neovim/neovim/releases]
 |see below
 |===
 
-==== Installing the tree-sitter CLI
+=== Installing the tree-sitter CLI
 
 kulala.nvim ships a custom `kulala++_++http` tree-sitter grammar that
 nvim-treesitter compiles from source the first time you open an `.http`
@@ -51,7 +51,7 @@ The compilation happens once; subsequent launches use the cached parser.
 kulala.nvim has *no LuaRocks dependencies* and installs as a plain git
 plugin.
 
-=== Quick Start
+== Quick Start
 
 [arabic]
 . Create a file with the `.http` extension, e.g. `api.http`.
@@ -69,7 +69,7 @@ Accept: application/json
 . The result pane opens automatically with the response body, headers,
 and timing stats.
 
-=== HTTP File Syntax
+== HTTP File Syntax
 
 [source,http]
 ----
@@ -79,7 +79,7 @@ Header-field: Header-value
 Request-Body
 ----
 
-==== Example: GET request
+=== Example: GET request
 
 [source,http]
 ----
@@ -87,7 +87,7 @@ GET https://api.example.com/users HTTP/1.1
 Accept: application/json
 ----
 
-==== Example: POST request with JSON body
+=== Example: POST request with JSON body
 
 [source,http]
 ----
@@ -100,7 +100,7 @@ Content-Type: application/json
 }
 ----
 
-==== Example: Named request
+=== Example: Named request
 
 [source,http]
 ----
@@ -113,7 +113,7 @@ Content-Type: application/json
 }
 ----
 
-=== Environment Variables
+== Environment Variables
 
 kulala.nvim supports two env file formats:
 
@@ -152,7 +152,7 @@ Authorization: Bearer {{api_key}}
 Use `,e` to pick which named environment from `http-client.env.json` is
 active.
 
-=== Typical Workflow
+== Typical Workflow
 
 [arabic]
 . Create `requests.http` with your API calls.
@@ -162,9 +162,9 @@ active.
 . Press `,l` to quickly re-run the last request after editing it.
 . Press `,o` to re-open the result pane if closed.
 
-=== Keybindings
+== Keybindings
 
-→ See the link:../cheatsheets/rest.adoc[REST cheatsheet] for the full
+→ See the link:../cheatsheets/rest.md[REST cheatsheet] for the full
 keybinding reference.
 
 [cols=",",options="header",]
@@ -176,9 +176,9 @@ keybinding reference.
 |`,e` |Select environment
 |===
 
-=== Troubleshooting
+== Troubleshooting
 
-==== `ENOENT: no such file or directory (cmd): 'tree-sitter'`
+=== `ENOENT: no such file or directory (cmd): 'tree-sitter'`
 
 kulala.nvim builds its custom `kulala++_++http` tree-sitter grammar on
 first launch using the `tree-sitter` CLI. If the binary is not on your
@@ -192,7 +192,7 @@ first launch using the `tree-sitter` CLI. If the binary is not on your
 link:#installing-the-tree-sitter-cli[Installing the tree-sitter CLI]
 above), then *restart Neovim*.
 
-==== `async.lua: timeout` / `Failed to run config for kulala.nvim`
+=== `async.lua: timeout` / `Failed to run config for kulala.nvim`
 
 Same root cause — nvim-treesitter timed out waiting for
 `tree-sitter build` to complete because the binary was not found.
@@ -200,7 +200,7 @@ Same root cause — nvim-treesitter timed out waiting for
 *Fix:* same as above — install the tree-sitter CLI, then *restart
 Neovim*.
 
-==== All keymaps (`,r` `,l` `,o` `,e`) do nothing after the error
+=== All keymaps (`,r` `,l` `,o` `,e`) do nothing after the error
 
 When kulala’s `setup()` errors (either due to the missing CLI or the
 timeout), the UI layer is never initialized. Every keymap that calls
@@ -211,7 +211,7 @@ show `nil` errors until kulala initializes successfully.
 file. The grammar is compiled once on this first successful launch;
 subsequent starts will use the cached parser and load instantly.
 
-=== Configuration
+== Configuration
 
 kulala.nvim is configured via `opts` in `lua/plugins/rest.lua`. The
 defaults are sensible for most use cases. To customise:

--- a/docs/modules/ROOT/pages/guides/validation.adoc
+++ b/docs/modules/ROOT/pages/guides/validation.adoc
@@ -16,7 +16,7 @@ command mode. - Commands prefixed `$` are run in a shell. -
 
 '''''
 
-=== Prerequisites
+== Prerequisites
 
 Before starting, confirm the following are installed and available:
 
@@ -36,7 +36,7 @@ docs/guides/cli-console-mode.md for install)
 
 '''''
 
-=== 1. Lua Syntax Check
+== 1. Lua Syntax Check
 
 Verify all Lua files are syntactically valid.
 
@@ -52,7 +52,7 @@ find ~/.config/nvim -name '*.lua' \
 
 '''''
 
-=== 2. Startup and Plugin Loading
+== 2. Startup and Plugin Loading
 
 * [x] 2.1 Open Neovim with no file argument:
 +
@@ -80,7 +80,7 @@ show `✗ error`.
 
 '''''
 
-=== 3. Console Detection
+== 3. Console Detection
 
 * [ ] 3.1 In a normal GUI/WSL session, confirm `is++_++console` is
 false:
@@ -113,7 +113,7 @@ env -u DISPLAY -u WAYLAND_DISPLAY nvim
 
 '''''
 
-=== 4. Markdown Preview — Glow (console)
+== 4. Markdown Preview — Glow (console)
 
 *Precondition:* `glow` is on `$PATH`. Launch in console mode:
 
@@ -187,7 +187,7 @@ crash. Restore: `:lua vim.env.PATH = vim.fn.system("echo -n $PATH")`
 
 '''''
 
-=== 5. Markdown Preview — markdown-preview.nvim (GUI)
+== 5. Markdown Preview — markdown-preview.nvim (GUI)
 
 *Precondition:* running in a GUI session with `$DISPLAY` or
 `$WAYLAND++_++DISPLAY` set.
@@ -223,7 +223,7 @@ opens in Neovim.
 
 '''''
 
-=== 6. Markdown Preview — Markserv (cross-page links)
+== 6. Markdown Preview — Markserv (cross-page links)
 
 *Precondition:* Docker is running.
 
@@ -257,7 +257,7 @@ docker compose -f ~/.config/nvim/docker/markserv/docker-compose.yml down
 
 '''''
 
-=== 7. PlantUML Docker Server
+== 7. PlantUML Docker Server
 
 *Precondition:* Docker is running. This server is required for sections
 8 and 9.
@@ -290,7 +290,7 @@ EOF
 
 '''''
 
-=== 8. PlantUML ASCII Preview
+== 8. PlantUML ASCII Preview
 
 *Precondition:* PlantUML server from section 7 is running.
 
@@ -350,7 +350,7 @@ nvim /tmp/test.puml
 
 '''''
 
-=== 9. Markdown → PDF Export (with diagrams)
+== 9. Markdown → PDF Export (with diagrams)
 
 *Precondition:* PlantUML server from section 7 is running.
 
@@ -396,7 +396,7 @@ ls -la /tmp/test-diagrams.pdf
 
 '''''
 
-=== 10. MARP Presentations
+== 10. MARP Presentations
 
 *Precondition:* Docker is running.
 
@@ -458,7 +458,7 @@ MARP preview server.
 
 '''''
 
-=== 11. Avante AI — Ollama Backend
+== 11. Avante AI — Ollama Backend
 
 *Precondition:* Both steps are required on first use.
 
@@ -513,7 +513,7 @@ docker compose -f ~/.config/nvim/docker/ollama/docker-compose.yml start
 
 '''''
 
-=== 12. Avante AI — Copilot Backend
+== 12. Avante AI — Copilot Backend
 
 *Precondition:* Copilot is authenticated.
 
@@ -530,7 +530,7 @@ streams in. No separate login prompt.
 
 '''''
 
-=== 13. Copilot Inline Completion
+== 13. Copilot Inline Completion
 
 * [ ] 13.1 Open a code file (e.g. a `.lua` or `.py` file) and start
 typing a function:
@@ -550,7 +550,7 @@ explanation in a popup or panel.
 
 '''''
 
-=== 14. LSP
+== 14. LSP
 
 *Precondition:* at least one LSP server is configured (e.g. open a
 `.lua` file — `lua++_++ls` if installed, or a `.fs` file for
@@ -587,7 +587,7 @@ clean).
 
 '''''
 
-=== 15. FZF Fuzzy Finder
+== 15. FZF Fuzzy Finder
 
 * [ ] 15.1 Open file finder:
 +
@@ -614,7 +614,7 @@ clean).
 
 '''''
 
-=== 16. Nvim-Tree File Explorer
+== 16. Nvim-Tree File Explorer
 
 * [ ] 16.1 Open file tree:
 +
@@ -634,7 +634,7 @@ or `++<++C-n++>++`. *Expected:* file tree sidebar opens.
 
 '''''
 
-=== 17. Git (Fugitive {plus} Gitsigns)
+== 17. Git (Fugitive {plus} Gitsigns)
 
 *Precondition:* inside a git repository.
 
@@ -658,7 +658,7 @@ appear in the gutter.
 
 '''''
 
-=== 18. REST Client (Kulala)
+== 18. REST Client (Kulala)
 
 *Precondition:* a `.http` file with a valid request.
 
@@ -695,7 +695,7 @@ nvim /tmp/test.http
 
 '''''
 
-=== 19. Common Lisp REPL (Conjure {plus} Swank)
+== 19. Common Lisp REPL (Conjure {plus} Swank)
 
 *Precondition:* Docker is running.
 
@@ -729,7 +729,7 @@ echo '(+ 1 2)' > /tmp/test.lisp && nvim /tmp/test.lisp
 
 '''''
 
-=== 20. F++#++ REPL (iron.nvim)
+== 20. F++#++ REPL (iron.nvim)
 
 *Precondition:* `dotnet` CLI is installed (`which dotnet`).
 
@@ -755,7 +755,7 @@ echo 'printfn "Hello"' > /tmp/test.fsx && nvim /tmp/test.fsx
 
 '''''
 
-=== 21. Haskell (haskell-tools {plus} GHCi)
+== 21. Haskell (haskell-tools {plus} GHCi)
 
 *Precondition:* `ghc` and `haskell-language-server` are installed.
 
@@ -781,7 +781,7 @@ echo 'main = putStrLn "hi"' > /tmp/Test.hs && nvim /tmp/Test.hs
 
 '''''
 
-=== 22. Confluence Integration
+== 22. Confluence Integration
 
 *Precondition:* `CONFLUENCE++_++EMAIL` and
 `CONFLUENCE++_++API++_++TOKEN` env vars are set. See
@@ -817,7 +817,7 @@ meaningful message (not `E492: Not an editor command`).
 
 '''''
 
-=== 23. Jira Integration
+== 23. Jira Integration
 
 *Precondition:* `JIRA++_++EMAIL`, `JIRA++_++API++_++TOKEN`, and
 `JIRA++_++BASE++_++URL` env vars are set. See `docs/guides/jira.md` for
@@ -847,7 +847,7 @@ a meaningful message if credentials are missing).
 
 '''''
 
-=== 24. OpenSpec Workflow
+== 24. OpenSpec Workflow
 
 * [ ] 24.1 Confirm OpenSpec commands are registered:
 +
@@ -868,7 +868,7 @@ a meaningful message if credentials are missing).
 
 '''''
 
-=== 25. Terminal Toggle
+== 25. Terminal Toggle
 
 * [ ] 25.1 Open terminal split:
 +
@@ -890,7 +890,7 @@ buffer) — does *not* close the terminal.
 
 '''''
 
-=== 26. Formatting (conform.nvim)
+== 26. Formatting (conform.nvim)
 
 * [ ] 26.1 Open a Lisp or F++#++ file with intentionally bad
 indentation, then save:
@@ -912,13 +912,13 @@ indentation, then save:
 
 '''''
 
-=== 27. System Clipboard
+== 27. System Clipboard
 
 These tests verify the clipboard provider is correctly selected and that
 the `++<++leader++>++` shortcuts work. Run in the environment that
 matches the platform you want to verify.
 
-==== 27.1 Identify the active provider
+=== 27.1 Identify the active provider
 
 [source,vim]
 ----
@@ -933,7 +933,7 @@ matches the platform you want to verify.
 |GUI Linux |`unnamedplus (auto)`
 |===
 
-==== GUI Linux — xclip / xsel / wl-clipboard
+=== GUI Linux — xclip / xsel / wl-clipboard
 
 * [ ] 27.2 Confirm `:checkhealth clipboard` shows a provider found
 (xclip, xsel, or wl-copy):
@@ -957,7 +957,7 @@ external application shows the deleted line.
 press `++<++leader++>++p`. *Expected:* the external text is pasted after
 the cursor.
 
-==== WSL — win32yank.exe
+=== WSL — win32yank.exe
 
 * [ ] 27.6 Verify `win32yank.exe` is on `$PATH`:
 +
@@ -981,7 +981,7 @@ Notepad.
 * [ ] 27.9 Copy text in Notepad, then paste in Neovim with
 `++<++leader++>++p`. *Expected:* the Windows clipboard text is pasted.
 
-==== SSH / Console — OSC 52
+=== SSH / Console — OSC 52
 
 *Precondition:* connect via SSH from a terminal that supports OSC 52
 (Windows Terminal, Alacritty, kitty, WezTerm, Ghostty). Or simulate
@@ -1009,7 +1009,7 @@ pasted (terminals that block OSC 52 read for security). This is
 acceptable — use `Shift{plus}Insert` or `Ctrl{plus}Shift{plus}V` as the
 fallback.
 
-==== Keymaps — all platforms
+=== Keymaps — all platforms
 
 * [ ] 27.13 In visual mode, select text and press `++<++leader++>++y`.
 *Expected:* selection is copied to the system clipboard without leaving
@@ -1025,7 +1025,7 @@ replaced text goes to the black-hole register, clipboard is preserved).
 
 '''''
 
-=== Summary Checklist
+== Summary Checklist
 
 [cols=",,",options="header",]
 |===

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -7,7 +7,10 @@
 Representing a NeoVIM installation that looks and feels like I’m in
 coding land.
 
-=== Installation
+📖 *https://floatingman-ltd.github.io/arcane-centaur[Full documentation
+site →]*
+
+== Installation
 
 Clone this repo into your Neovim config directory:
 
@@ -19,7 +22,7 @@ git clone https://github.com/floatingman-ltd/arcane-centaur ~/.config/nvim
 On first launch, https://github.com/folke/lazy.nvim[lazy.nvim] will
 bootstrap itself and install all plugins automatically.
 
-==== Prerequisites
+=== Prerequisites
 
 [width="100%",cols="34%,33%,33%",options="header",]
 |===
@@ -56,7 +59,7 @@ link:docs/guides/architecture.md[Architecture] ·
 link:docs/guides/validation.md[Validation] ·
 link:docs/guides/clipboard.md[Clipboard]
 
-==== Recommended Terminal — GNOME Terminal
+=== Recommended Terminal — GNOME Terminal
 
 https://help.gnome.org/users/gnome-terminal/stable/[GNOME Terminal] is
 the default terminal emulator for this configuration. It ships with most
@@ -80,7 +83,7 @@ installing a Nerd Font, set the override in `lua/options.lua`:
 vim.g.have_nerd_font = true
 ----
 
-===== Installing GNOME Terminal
+==== Installing GNOME Terminal
 
 GNOME Terminal is pre-installed on most GNOME-based distributions. If it
 is not present:
@@ -93,7 +96,7 @@ is not present:
 |*Arch Linux* |`sudo pacman -S gnome-terminal`
 |===
 
-===== Windows Terminal (WSL)
+==== Windows Terminal (WSL)
 
 https://aka.ms/terminal[Windows Terminal] is fully supported when
 running Neovim inside *WSL* (Windows Subsystem for Linux). The config
@@ -134,7 +137,7 @@ built-in clipboard provider detection (`xclip`, `xsel`, etc.), which may
 be slower or require an X server.
 ____
 
-===== Secondary Terminal — TTY Console
+==== Secondary Terminal — TTY Console
 
 The Linux TTY console (accessed with *Ctrl{plus}Alt{plus}F2* through
 *F6*) is supported as a secondary terminal. It is useful in minimal or
@@ -156,7 +159,7 @@ has full Nerd Font and undercurl support. The Neovim config auto-detects
 it and enables the appropriate features.
 ____
 
-===== Nerd Font Setup
+==== Nerd Font Setup
 
 `nvim-tree` and `fzf-lua` can display file-type icons when a patched
 https://www.nerdfonts.com/[Nerd Font] is installed *and* selected as the
@@ -172,7 +175,7 @@ https://www.nerdfonts.com/font-downloads.
 . Select it in your terminal emulator (GNOME Terminal: _Preferences →
 Profiles → Custom font_, or see your terminal’s documentation).
 
-===== Terminal Auto-Detection
+==== Terminal Auto-Detection
 
 The configuration automatically detects which terminal emulator is
 running (via `$TERM++_++PROGRAM`, `$VTE++_++VERSION`, and related
@@ -206,7 +209,7 @@ auto-detection is wrong for your setup you can still force the flag in
 vim.g.have_nerd_font = true   -- or false
 ----
 
-=== Working with Markdown
+== Working with Markdown
 
 → See *docs/guides/markdown.md* for the full guide: single-file browser
 preview, markserv Docker server for cross-page links, in-editor
@@ -220,7 +223,18 @@ PlantUML/Mermaid diagrams rendered
 (mkdnflow.nvim)
 * *`,cc`* — publish current file to Confluence (`MdToConfluence`)
 
-=== Working with Confluence
+== Working with AsciiDoc
+
+The `,p` and `,pp` preview keymaps work in `.adoc` buffers. Both trigger
+the same one-shot convert-and-open HTML flow (no popup equivalent for
+AsciiDoc output):
+
+* *`,p`* / *`,pp`* — convert via Docker asciidoctor → HTML → open in
+system browser (GUI only)
+
+Requires Docker. See *docker/asciidoctor/README.md* for details.
+
+== Working with Confluence
 
 → See *docs/guides/confluence.md* for the full guide: authentication,
 page map setup, diagram rendering, conflict detection, and
@@ -238,7 +252,7 @@ troubleshooting.
 (`MdConfluenceComments`)
 |===
 
-=== Working with Jira
+== Working with Jira
 
 → See *docs/guides/jira.md* for the full guide: authentication, project
 map setup, and troubleshooting.
@@ -255,7 +269,7 @@ Requires `JIRA++_++EMAIL`, `JIRA++_++API++_++TOKEN`, and
 |`,js` |Visual |Create a Story with selection as description
 |===
 
-=== Working with Diagrams
+== Working with Diagrams
 
 → See *docs/guides/diagrams.md* for the full guide: PlantUML and Mermaid
 in Markdown, standalone `.puml` files, Docker server setup, keybindings,
@@ -265,32 +279,32 @@ Mermaid fenced code blocks (`++```++mermaid` … `++```++`) render
 natively in the browser preview — *no extra plugin required*. PlantUML
 rendering uses a local Docker server.
 
-=== Working with F
+== Working with F
 
 → See *docs/guides/fsharp.md* for the full guide: iron.nvim REPL,
 fsautocomplete LSP, Quick Start, and Typical Workflow.
 
-=== Working with Haskell
+== Working with Haskell
 
 → See *docs/guides/haskell.md* for the full guide: haskell-tools.nvim,
 hls LSP, and GHCi REPL keybindings.
 
-=== Working with Janet
+== Working with Janet
 
 → See *docs/guides/janet.md* for the full guide: Conjure REPL, vim-sexp
 structural editing, janet-lsp, Quick Start, and Typical Workflow.
 
-=== Working with Lisp
+== Working with Lisp
 
 → See *docs/guides/lisp.md* for the full guide: Conjure, vim-sexp,
 parinfer, rainbow-delimiters, Quick Start, and Typical Workflow.
 
-=== Working with Presentations (MARP)
+== Working with Presentations (MARP)
 
 → See *docs/guides/presentations.md* for the full guide: MARP live
 preview via Docker, export to PPTX / HTML / PDF, and keybindings.
 
-=== Working with Git
+== Working with Git
 
 Git integration is provided by two complementary plugins:
 
@@ -298,8 +312,10 @@ Git integration is provided by two complementary plugins:
 `:Git commit`, `:Git log`, etc.)
 * *gitsigns.nvim* — live gutter signs showing added / changed / removed
 lines, with hunk-level staging, resetting, and inline blame
+* *diffview.nvim* — tabbed side-by-side diff panel, per-file commit
+history, and three-way merge conflict view
 
-==== Quick keybindings
+=== Quick keybindings
 
 [cols=",",options="header",]
 |===
@@ -309,6 +325,9 @@ lines, with hunk-level staging, resetting, and inline blame
 |`++<++leader++>++gl` |Git log
 |`++<++leader++>++gd` |Diff unstaged changes
 |`++<++leader++>++gp` |Push
+|`++<++leader++>++gD` |Open diff view (side-by-side, all changes)
+|`++<++leader++>++gH` |File history for current file
+|`++<++leader++>++gX` |Close diff view
 |`++]++h` / `++[++h` |Jump to next / previous changed hunk
 |`++<++leader++>++hs` |Stage hunk under cursor
 |`++<++leader++>++hr` |Reset hunk under cursor
@@ -323,7 +342,7 @@ in Haskell buffers (buffer-local, so it takes priority there). Use the
 fugitive status window to stage changes while editing Haskell files.
 ____
 
-=== Working with REST APIs (kulala.nvim)
+== Working with REST APIs (kulala.nvim)
 
 → See *docs/guides/rest.md* for the full guide: writing `.http` files,
 environment variables, and typical workflow.
@@ -349,7 +368,7 @@ ____
 |`,e` |Select environment
 |===
 
-=== LSP Support
+== LSP Support
 
 LSP servers are configured in `lua/config/lsp.lua`. See each language’s
 doc for server-specific setup. All servers share these keybindings
@@ -369,7 +388,7 @@ Keybindings:
 |`++[++d` / `++]++d` |Previous / next diagnostic
 |===
 
-=== General Keybindings
+== General Keybindings
 
 → See *docs/cheatsheets/index.md* for the complete one-page keybinding
 reference.
@@ -423,19 +442,19 @@ preview popup (`PumlPreviewAscii`)
 |`++<++leader++>++osl` |Normal |OpenSpec: list all changes
 |===
 
-=== Auto-Completion
+== Auto-Completion
 
 Auto-completion is powered by
 https://github.com/hrsh7th/nvim-cmp[nvim-cmp] and draws from LSP,
 snippets, open buffers, file paths, and (when spell-checking is active)
 the spell dictionary.
 
-==== Triggering the menu
+=== Triggering the menu
 
 The completion menu opens automatically as you type. To open it on
 demand in insert mode, press *`Alt{plus}Space`* (`++<++M-Space++>++`).
 
-==== Navigating the menu
+=== Navigating the menu
 
 Once the menu is open, use *`j`* and *`k`* to move through suggestions —
 matching the standard Neovim screen-movement keys. Both keys fall back
@@ -450,18 +469,18 @@ to inserting the literal character when the menu is not visible.
 |`Ctrl-b` |Scroll the documentation preview up
 |===
 
-==== Selecting the highlighted entry
+=== Selecting the highlighted entry
 
 Press *`Enter`* (`++<++CR++>++`) to confirm and insert the currently
 highlighted suggestion. If nothing is highlighted, `Enter` inserts a
 newline as normal (selection is never forced automatically).
 
-==== Cancelling the menu
+=== Cancelling the menu
 
 Press *`Ctrl{plus}e`* to dismiss the completion menu and return to
 normal typing.
 
-=== Supported Languages
+== Supported Languages
 
 [width="99%",cols="20%,16%,16%,16%,16%,16%",options="header",]
 |===
@@ -499,7 +518,7 @@ normal typing.
 |docs/guides/lisp.md
 |===
 
-=== Copilot Model Configuration
+== Copilot Model Configuration
 
 Edit `lua/plugins/copilot.lua` and uncomment the desired
 `vim.g.copilot++_++model` line:
@@ -516,13 +535,13 @@ end,
 
 Common values: `"gpt-4o"`, `"gpt-4.1"`, `"claude-sonnet-4-5"`.
 
-=== GitHub Copilot CLI
+== GitHub Copilot CLI
 
 The https://github.com/github/copilot-cli[GitHub Copilot CLI]
 (`@github/copilot` npm package) brings Copilot AI assistance to your
 terminal and is integrated directly into Neovim.
 
-==== Installation
+=== Installation
 
 [source,sh]
 ----
@@ -534,7 +553,7 @@ copilot
 # then enter: /login
 ----
 
-==== In-editor usage
+=== In-editor usage
 
 [width="100%",cols="50%,50%",options="header",]
 |===
@@ -566,7 +585,7 @@ npm install -g @oramasearch/serena
 Or run it without a global install via `npx @oramasearch/serena`.
 ____
 
-=== AI Research (Avante)
+== AI Research (Avante)
 
 https://github.com/yetone/avante.nvim[avante.nvim] provides an in-editor
 Q&A chat interface with two switchable backends: a local
@@ -584,7 +603,7 @@ Docker service, model download, GPU opt-in).
 |`++<++leader++>++ac` |Switch to copilot provider and open avante
 |===
 
-=== Plugin Overview
+== Plugin Overview
 
 Plugins are managed by https://github.com/folke/lazy.nvim[lazy.nvim] and
 organized in `lua/plugins/`:
@@ -615,7 +634,8 @@ link:docs/cheatsheets/dotnet.md[dotnet.md]
 |`fzf-lua.lua` |Fuzzy finder |link:docs/cheatsheets/fzf.md[fzf.md]
 
 |`git.lua` |vim-fugitive (`:Git` commands) {plus} gitsigns.nvim (hunk
-signs & staging) |link:docs/cheatsheets/git.md[git.md]
+signs & staging) {plus} diffview.nvim (side-by-side diff & history)
+|link:docs/cheatsheets/git.md[git.md]
 
 |`haskell.lua` |haskell-tools.nvim (GHCi REPL {plus} HLS integration)
 |link:docs/cheatsheets/haskell.md[haskell.md]
@@ -661,7 +681,7 @@ ASCII in console) {plus} `:PumlPreviewAscii` (always available)
 |link:docs/cheatsheets/comments.md[comments.md]
 |===
 
-=== Project Structure
+== Project Structure
 
 ....
 init.lua                    # Entry point
@@ -688,7 +708,7 @@ lua/
     copilot.lua             # Copilot inline completions + Serena MCP server config
     dotnet.lua              # F# + C# REPLs via iron.nvim; roslyn.nvim C# LSP
     fzf-lua.lua             # Fuzzy finder
-    git.lua                 # Git (vim-fugitive + gitsigns.nvim)
+    git.lua                 # Git (vim-fugitive + gitsigns.nvim + diffview.nvim)
     haskell.lua             # haskell-tools.nvim (GHCi REPL + HLS)
     html.lua                # Bracey HTML live preview
     init.lua                # Bare-string plugins (tpope, airline, lspconfig)
@@ -752,11 +772,3 @@ docs/
     presentations.md        # MARP presentation guide
     rest.md                 # REST client guide (kulala.nvim, .http files)
 ....
-
-== Documentation
-
-The full documentation site is published at
-https://floatingman-ltd.github.io/arcane-centaur[floatingman-ltd.github.io/arcane-centaur].
-
-It includes guides, cheatsheets, and learning content built from the `docs/` directory
-using https://antora.org[Antora] and redeployed automatically on every push to `main`.

--- a/docs/modules/ROOT/pages/jira-project-map.adoc
+++ b/docs/modules/ROOT/pages/jira-project-map.adoc
@@ -13,7 +13,7 @@ determine which Jira project to file tickets in.
 directory prefix (e.g. `docs/`) matches any file under it. - An exact
 file path also works (e.g. `docs/design/payment.md`).
 
-=== Project Map
+== Project Map
 
 [cols=",,",options="header",]
 |===

--- a/docs/modules/ROOT/pages/learning/janet/01-setup.adoc
+++ b/docs/modules/ROOT/pages/learning/janet/01-setup.adoc
@@ -9,13 +9,13 @@ toolchain that is already configured in this repository — LSP, REPL,
 structural editing, formatting, and rainbow delimiters.
 
 ____
-*Series:* 01 Setup ← you are here · xref:learning/janet/02-first-steps.adoc[02 First
+*Series:* 01 Setup ← you are here · link:02-first-steps.md[02 First
 Steps]
 ____
 
 '''''
 
-=== 1. Install Janet
+== 1. Install Janet
 
 Janet has no runtime dependencies and ships as a single binary.
 
@@ -41,7 +41,7 @@ janet -v
 
 '''''
 
-=== 2. Install jpm (Janet Package Manager)
+== 2. Install jpm (Janet Package Manager)
 
 `jpm` is the standard package manager for Janet libraries and tools. It
 is bundled with most Janet installations. Confirm it is available:
@@ -65,7 +65,7 @@ instructions.
 
 '''''
 
-=== 3. Install the LSP Server
+== 3. Install the LSP Server
 
 `janet-lsp` provides completions, hover documentation, go-to-definition,
 and inline diagnostics inside Neovim.
@@ -93,7 +93,7 @@ which janet-lsp
 
 '''''
 
-=== 4. How the Neovim Plugins Are Wired
+== 4. How the Neovim Plugins Are Wired
 
 Everything is pre-configured. When you open any `.janet` file the
 following plugins load automatically:
@@ -125,7 +125,7 @@ live in `after/ftplugin/janet.lua`.
 
 '''''
 
-=== 5. Verify the Setup
+== 5. Verify the Setup
 
 [arabic]
 . Open (or create) a Janet file:
@@ -149,7 +149,7 @@ appear.
 
 '''''
 
-=== 6. Troubleshooting
+== 6. Troubleshooting
 
 [width="100%",cols="34%,33%,33%",options="header",]
 |===
@@ -172,5 +172,5 @@ For deeper LSP debugging see `docs/cheatsheets/lsp.md` and run
 
 '''''
 
-*Next:* xref:learning/janet/02-first-steps.adoc[02 — First Steps: syntax&#44; data
+*Next:* link:02-first-steps.md[02 — First Steps: syntax&#44; data
 types&#44; and using the tools]

--- a/docs/modules/ROOT/pages/learning/janet/02-first-steps.adoc
+++ b/docs/modules/ROOT/pages/learning/janet/02-first-steps.adoc
@@ -9,12 +9,12 @@ to use each Neovim tool hands-on. Work through it interactively —
 evaluate every snippet as you read.
 
 ____
-*Series:* xref:learning/janet/01-setup.adoc[01 Setup] · 02 First Steps ← you are here
+*Series:* link:01-setup.md[01 Setup] · 02 First Steps ← you are here
 ____
 
 '''''
 
-=== 1. Open a Scratch File
+== 1. Open a Scratch File
 
 [source,sh]
 ----
@@ -32,7 +32,7 @@ Everything you evaluate will appear in the right-hand pane.
 
 '''''
 
-=== 2. Core Syntax at a Glance
+== 2. Core Syntax at a Glance
 
 Janet is a Lisp. Every expression is a function call wrapped in
 parentheses:
@@ -58,9 +58,9 @@ buffer).
 
 '''''
 
-=== 3. Data Types
+== 3. Data Types
 
-==== Numbers
+=== Numbers
 
 [source,janet]
 ----
@@ -69,7 +69,7 @@ buffer).
 0xFF        # hex integer (255)
 ----
 
-==== Strings
+=== Strings
 
 [source,janet]
 ----
@@ -79,7 +79,7 @@ buffer).
 (string/upcase "janet")          # => "JANET"
 ----
 
-==== Keywords
+=== Keywords
 
 Keywords are interned symbols prefixed with `:`. They evaluate to
 themselves and are commonly used as map keys:
@@ -90,7 +90,7 @@ themselves and are commonly used as map keys:
 :age
 ----
 
-==== Arrays (mutable)
+=== Arrays (mutable)
 
 [source,janet]
 ----
@@ -99,7 +99,7 @@ themselves and are commonly used as map keys:
 arr   # => @[1 2 3 4]
 ----
 
-==== Tuples (immutable)
+=== Tuples (immutable)
 
 [source,janet]
 ----
@@ -107,7 +107,7 @@ arr   # => @[1 2 3 4]
 (get t 0)   # => 1
 ----
 
-==== Tables (mutable maps)
+=== Tables (mutable maps)
 
 [source,janet]
 ----
@@ -117,7 +117,7 @@ arr   # => @[1 2 3 4]
 person                      # => @{:name "Alice" :age 31}
 ----
 
-==== Structs (immutable maps)
+=== Structs (immutable maps)
 
 [source,janet]
 ----
@@ -127,9 +127,9 @@ person                      # => @{:name "Alice" :age 31}
 
 '''''
 
-=== 4. Defining Things
+== 4. Defining Things
 
-==== Variables
+=== Variables
 
 [source,janet]
 ----
@@ -138,7 +138,7 @@ person                      # => @{:name "Alice" :age 31}
 (set counter 1)     # mutate a var
 ----
 
-==== Functions
+=== Functions
 
 [source,janet]
 ----
@@ -156,7 +156,7 @@ Functions are first-class values:
 (double 5)   # => 10
 ----
 
-==== Let bindings (local scope)
+=== Let bindings (local scope)
 
 [source,janet]
 ----
@@ -167,9 +167,9 @@ Functions are first-class values:
 
 '''''
 
-=== 5. Control Flow
+== 5. Control Flow
 
-==== if / if-not
+=== if / if-not
 
 [source,janet]
 ----
@@ -178,7 +178,7 @@ Functions are first-class values:
   "no")   # => "yes"
 ----
 
-==== when (no else branch)
+=== when (no else branch)
 
 [source,janet]
 ----
@@ -186,7 +186,7 @@ Functions are first-class values:
   (print "this runs"))
 ----
 
-==== cond (multi-branch)
+=== cond (multi-branch)
 
 [source,janet]
 ----
@@ -197,7 +197,7 @@ Functions are first-class values:
   "positive")   # => "positive"
 ----
 
-==== loop and each
+=== loop and each
 
 [source,janet]
 ----
@@ -210,9 +210,9 @@ Functions are first-class values:
 
 '''''
 
-=== 6. Using the Neovim Tools
+== 6. Using the Neovim Tools
 
-==== Conjure — Evaluating Code
+=== Conjure — Evaluating Code
 
 [cols=",",options="header",]
 |===
@@ -228,7 +228,7 @@ Functions are first-class values:
 *Try it:* place the cursor anywhere inside `(greet "Walt")` and press
 `,ee`.
 
-==== vim-sexp — Structural Editing
+=== vim-sexp — Structural Editing
 
 vim-sexp lets you reshape code without manually counting parentheses.
 All motions work in normal mode.
@@ -264,7 +264,7 @@ All motions work in normal mode.
 *Try it:* on the `greet` definition, position the cursor on `"Hello, "`
 and press `++>++)` — watch the closing paren jump right.
 
-==== nvim-parinfer — Indent-Driven Parens
+=== nvim-parinfer — Indent-Driven Parens
 
 Parinfer infers where closing parentheses belong based on your
 indentation. There are no keymaps — just indent with `++>>++` or Tab and
@@ -273,13 +273,13 @@ watch the parens follow.
 *Key rule:* edit indentation to move code into or out of a form; do not
 manually drag parentheses.
 
-==== rainbow-delimiters — Visual Nesting
+=== rainbow-delimiters — Visual Nesting
 
 Each nesting level gets a distinct colour automatically. No keymaps
 needed. Use the colours to orient yourself when editing deeply nested
 expressions.
 
-==== LSP — Language Intelligence
+=== LSP — Language Intelligence
 
 The `janet++_++lsp` server activates automatically when you open a
 `.janet` file. Standard LSP keymaps (from `lua/config/lsp.lua`):
@@ -298,7 +298,7 @@ The `janet++_++lsp` server activates automatically when you open a
 
 Check the server is running: `:LspInfo`
 
-==== conform.nvim — Formatting
+=== conform.nvim — Formatting
 
 Format-on-save is active for Janet. To trigger manually:
 
@@ -311,7 +311,7 @@ mode)
 
 '''''
 
-=== 7. A Complete Mini-Project
+== 7. A Complete Mini-Project
 
 Put this in `scratch.janet`, then evaluate forms top-to-bottom with
 `,er`:
@@ -342,7 +342,7 @@ function is defined. 3. Position cursor on `(lookup :alice)` and press
 
 '''''
 
-=== 8. What to Explore Next
+== 8. What to Explore Next
 
 * *Janet standard library:* run `(doc string)`, `(doc array)`, etc. in
 the REPL to read built-in documentation.

--- a/scripts/convert-docs.sh
+++ b/scripts/convert-docs.sh
@@ -56,7 +56,7 @@ convert_file() {
     echo "// :source: $src"
     echo "// Remove this header to take manual ownership of this file"
     echo ""
-    (cd "$REPO_ROOT" && "$PANDOC" -f markdown -t asciidoc "$src")
+    (cd "$REPO_ROOT" && "$PANDOC" -f markdown -t asciidoc "$src" | awk '/^={2,6} / { sub(/^=/, ""); } { print }')
   } > "$tmp"
 
   mv "$tmp" "${REPO_ROOT}/${dst}"


### PR DESCRIPTION
Pandoc maps Markdown # to == (not =) without --standalone. The original big-bang conversion only promoted the first == to = (document title) but left all H2+ headings one level too deep (=== instead of ==, etc.).

Fix: pipe pandoc output through awk to shift all heading levels down by one (/^={2,6} / { sub(/^=/, ""); }). This correctly produces:
  # Title  → = Title
  ## H2    → == H2
  ### H3   → === H3

Also:
- Restore sentinel on clipboard.adoc (was created without one)
- Take manual ownership of unimpaired.adoc and fix {motion} table cells (pandoc generates ++{++motion} which AsciiDoc still resolves as an attribute reference; fixed to ++{motion}++ passthrough)

All 43 auto-generated .adoc files regenerated.