### PR TITLE
refactor: remove custom Ctrl-/ keymaps from vim-commentary

### DIFF
--- a/docs/modules/ROOT/pages/cheatsheets/comments.adoc
+++ b/docs/modules/ROOT/pages/cheatsheets/comments.adoc
@@ -2,7 +2,7 @@
 // :source: documentation/cheatsheets/comments.md
 // Remove this header to take manual ownership of this file
 
-== Comments Cheatsheet (vim-commentary)
+= Comments Cheatsheet (vim-commentary)
 
 → Back to link:index.md[main cheatsheet]
 
@@ -16,9 +16,10 @@
 |`gc` |Visual |Toggle comment on selection
 
 |`gc++<++motion++>++` |Normal |Toggle comment over a motion (e.g. `gcap`
-= paragraph)
+= paragraph, `gc2j` = 3 lines)
 
-|`Ctrl-/` |Normal |Toggle comment — use `Ctrl-++_++` on most terminals
+|`:Commentary` |Command |Toggle comment on current line or range
+(e.g. `:'++<++,'++>++Commentary`)
 |===
 
 `vim-commentary` uses the correct comment syntax for each filetype
@@ -27,8 +28,4 @@ for Python, etc.).
 
 '''''
 
-_Plugin configured in `lua/plugins/vim-commentary.lua`. `gcc`, `gc`,
-`Ctrl-++_++`, and `Ctrl-/` keys are registered via lazy.nvim `keys` so
-the plugin loads on first use of any of them. Most terminals send
-`Ctrl-++_++` (byte 0x1F) when Ctrl{plus}/ is pressed; `Ctrl-/` is kept
-for terminals using the extended keyboard protocol (Kitty, WezTerm)._
+_Plugin configured in `lua/plugins/vim-commentary.lua`._

--- a/documentation/cheatsheets/comments.md
+++ b/documentation/cheatsheets/comments.md
@@ -8,12 +8,12 @@
 |---|---|---|
 | `gcc` | Normal | Toggle comment on current line |
 | `gc` | Visual | Toggle comment on selection |
-| `gc<motion>` | Normal | Toggle comment over a motion (e.g. `gcap` = paragraph) |
-| `Ctrl-/` | Normal | Toggle comment — use `Ctrl-_` on most terminals |
+| `gc<motion>` | Normal | Toggle comment over a motion (e.g. `gcap` = paragraph, `gc2j` = 3 lines) |
+| `:Commentary` | Command | Toggle comment on current line or range (e.g. `:'<,'>Commentary`) |
 
 `vim-commentary` uses the correct comment syntax for each filetype automatically
 (`--` for Lua, `//` for JavaScript, `;;` for Lisp, `#` for Python, etc.).
 
 ---
 
-*Plugin configured in `lua/plugins/vim-commentary.lua`. `gcc`, `gc`, `Ctrl-_`, and `Ctrl-/` keys are registered via lazy.nvim `keys` so the plugin loads on first use of any of them. Most terminals send `Ctrl-_` (byte 0x1F) when Ctrl+/ is pressed; `Ctrl-/` is kept for terminals using the extended keyboard protocol (Kitty, WezTerm).*
+*Plugin configured in `lua/plugins/vim-commentary.lua`.*

--- a/lua/plugins/vim-commentary.lua
+++ b/lua/plugins/vim-commentary.lua
@@ -1,10 +1,6 @@
 return {
   "tpope/vim-commentary",
   keys = {
-    -- <C-_> is the byte most terminals send for Ctrl+/; <C-/> covers terminals
-    -- that support the extended keyboard protocol (Kitty, WezTerm, etc.)
-    { "<C-_>", ":Commentary<CR>", mode = "n" },
-    { "<C-/>", ":Commentary<CR>", mode = "n" },
     { "gcc", mode = "n" },
     { "gc", mode = { "n", "x", "o" } },
   },


### PR DESCRIPTION
Use only the plugin's default keymaps (gcc, gc operator/visual). Remove <C-_> and <C-/> custom bindings.

Update comments cheatsheet: remove Ctrl-/ row, add :Commentary command and gc<motion> examples (gc2j), clarify operator-pending usage.