### PR TITLE
fix: handle nvim-ufo UfoFallbackException for markdown buffers

### DIFF
--- a/lua/plugins/ufo.lua
+++ b/lua/plugins/ufo.lua
@@ -4,7 +4,10 @@ return {
     dependencies = { "kevinhwang91/promise-async" },
     event = "BufReadPost",
     opts = {
-      provider_selector = function()
+      provider_selector = function(_, filetype, _)
+        if filetype == "markdown" then
+          return { "treesitter", "indent" }
+        end
         return { "lsp", "treesitter" }
       end,
       fold_virt_text_handler = function(virtText, lnum, endLnum, width, truncate)


### PR DESCRIPTION
marksman LSP does not provide fold ranges and markdown treesitter has no fold queries, leaving no fallback and causing the error. Use treesitter + indent for markdown, lsp + treesitter for everything else.