### PR TITLE
fix(ufo): disable treesitter folding to fix markdown preview errors

### DIFF
--- a/lua/plugins/ufo.lua
+++ b/lua/plugins/ufo.lua
@@ -4,11 +4,12 @@ return {
     dependencies = { "kevinhwang91/promise-async" },
     event = "BufReadPost",
     opts = {
-      provider_selector = function(_, filetype, _)
+      provider_selector = function(bufnr, filetype, _)
+        -- Disable treesitter folding entirely (causes errors on special buffers like glow)
         if filetype == "markdown" then
-          return { "treesitter", "indent" }
+          return { "indent" }
         end
-        return { "lsp", "treesitter" }
+        return { "lsp", "indent" }
       end,
       fold_virt_text_handler = function(virtText, lnum, endLnum, width, truncate)
         local newVirtText = {}


### PR DESCRIPTION
The treesitter folding provider was causing UnhandledPromiseRejection errors when opening markdown files and using the glow preview (,pp). Treesitter folding fails on special/temporary buffers like glow preview windows.

Solution: Remove treesitter as a folding provider and use LSP (with indent fallback) for code files and indent-only for markdown. This maintains folding functionality while avoiding the error-prone treesitter provider.

Fixes: Markdown preview (,pp) now works without errors
Tested: Opening markdown files and pressing ,pp in glow preview