### PR TITLE
feat(ide-layout): one-keystroke IDE layout with full-width terminal a…

### DIFF
--- a/cheatsheets/core.md
+++ b/cheatsheets/core.md
@@ -40,12 +40,14 @@
 | `Ctrl-t` | Toggle file tree |
 | `Ctrl-f` | Reveal current file in tree |
 
-## Terminal
+## IDE Layout & Terminal
 
 | Key | Action |
 |-----|--------|
-| `<leader>t` | Toggle terminal split (15-line) |
+| `<leader>L` | Assemble IDE layout (tree + editor + full-width terminal) |
+| `<leader>t` | Toggle full-width terminal (persistent shell) |
 | `Esc` | Exit terminal insert mode |
+| `:Bd` | Delete buffer, keep window open |
 
 ---
 

--- a/docs/modules/ROOT/pages/editor/keybindings.adoc
+++ b/docs/modules/ROOT/pages/editor/keybindings.adoc
@@ -92,13 +92,15 @@ Closed folds display `▸ <name> ··· N lines`. C# buffers use Roslyn LSP for 
 
 '''''
 
-=== Terminal
+=== Terminal & IDE Layout
 
 [cols=",,",options="header",]
 |===
 |Keys |Mode |Action
-|`++<++leader++>++t` |Normal |Toggle terminal split
+|`++<++leader++>++L` |Normal |Assemble IDE layout (tree + editor + full-width terminal)
+|`++<++leader++>++t` |Normal |Toggle full-width terminal split
 |`Esc` |Terminal |Exit terminal insert mode
+|`:Bd` |Normal |Delete buffer, keep window open (layout-preserving)
 |===
 
 → xref:editor/navigation.adoc[Full reference]

--- a/docs/modules/ROOT/pages/editor/navigation.adoc
+++ b/docs/modules/ROOT/pages/editor/navigation.adoc
@@ -19,20 +19,43 @@
 |`Ctrl-→` |Normal |Grow split width
 |===
 
+== IDE Layout
+
+Press `++<++leader++>++L` to assemble the IDE workspace in one keystroke:
+
+....
+┌────────────┬───────────────────┐
+│  nvim-tree │      editor       │
+├────────────┴───────────────────┤
+│   terminal (full width, 15)    │
+└────────────────────────────────┘
+....
+
+The operation is idempotent — invoking it when the layout is already
+assembled does nothing, and focus always returns to the editor window.
+
+=== Layout stability
+
+* `:Bd` — layout-preserving buffer delete. Switches the window to
+  another listed buffer (or a new empty one) before deleting, so the
+  window and the tree's width survive.
+* The tree closes automatically when quitting would leave it (and/or
+  the terminal panel) as the only remaining window — no more full-width
+  tree after `:q` on the last editor.
+
 == Terminal
 
 [width="100%",cols="34%,33%,33%",options="header",]
 |===
 |Keys |Mode |Action
-|`++<++leader++>++t` |Normal |Toggle terminal split (15-line split at
-bottom)
-
+|`++<++leader++>++t` |Normal |Toggle full-width terminal (persistent shell)
 |`Esc` |Terminal |Exit terminal insert mode
 |===
 
-The terminal toggle reuses the same terminal buffer across open/close
-cycles. Press `++<++C-k++>++` after `Esc` to jump back to the editor
-window.
+The terminal always opens as a full-width bottom split regardless of
+which window has focus. The shell buffer is reused across open/close
+cycles — history and running jobs survive window toggles. Press
+`++<++C-k++>++` after `Esc` to jump back to the editor window.
 
 == AI Chat Window
 

--- a/lua/keymaps.lua
+++ b/lua/keymaps.lua
@@ -76,8 +76,10 @@ local function toggle_terminal()
     end
   end
   -- Open a new split and start/reuse terminal
-  vim.cmd("split")
+  vim.cmd("botright split")
   vim.cmd("resize 15")
+  vim.wo.winfixheight = true
+  vim.wo.winfixheight = true
   if vim.api.nvim_buf_is_valid(term_buf) then
     vim.api.nvim_set_current_buf(term_buf)
   else
@@ -87,8 +89,83 @@ local function toggle_terminal()
   vim.cmd("startinsert")
 end
 
+local function ide_layout()
+  -- Find a normal editor window (not the tree, not a float, not a terminal)
+  local editor_win = nil
+  for _, win in ipairs(vim.api.nvim_list_wins()) do
+    if vim.api.nvim_win_get_config(win).relative == "" then  -- not a float
+      local buf = vim.api.nvim_win_get_buf(win)
+      if vim.bo[buf].buftype == "" and vim.bo[buf].filetype ~= "NvimTree" then
+        editor_win = win
+        break
+      end
+    end
+  end
+
+  -- Open tree via Lua API (avoids E464 ambiguous-command when called from tree buffer)
+  require("nvim-tree.api").tree.open()
+
+  -- Ensure terminal is visible; reuse the same open path as toggle_terminal
+  local term_visible = false
+  for _, win in ipairs(vim.api.nvim_list_wins()) do
+    if vim.api.nvim_win_get_buf(win) == term_buf then
+      term_visible = true
+      break
+    end
+  end
+  if not term_visible then
+    vim.cmd("botright split")
+    vim.cmd("resize 15")
+    vim.wo.winfixheight = true
+    if vim.api.nvim_buf_is_valid(term_buf) then
+      vim.api.nvim_set_current_buf(term_buf)
+    else
+      vim.cmd("term")
+      term_buf = vim.api.nvim_get_current_buf()
+    end
+    vim.cmd("stopinsert")
+  end
+
+  -- Return focus to the editor window; fall back to tree→right if needed
+  if editor_win and vim.api.nvim_win_is_valid(editor_win) then
+    vim.api.nvim_set_current_win(editor_win)
+  else
+    vim.cmd("wincmd t")
+    vim.cmd("wincmd l")
+  end
+end
+
 vim.keymap.set("n", "<leader>t", toggle_terminal, { noremap = true, silent = true, desc = "Toggle terminal split" })
+vim.keymap.set("n", "<leader>L", ide_layout,       { noremap = true, silent = true, desc = "IDE layout: tree + editor + terminal" })
 vim.keymap.set("t", "<Esc>", "<C-\\><C-n>", { noremap = true, silent = true, desc = "Exit terminal insert mode" })
+
+-- Layout-preserving buffer delete: switches every window showing the buffer to
+-- an alternate before deleting, so the window (and tree width) survives.
+vim.api.nvim_create_user_command("Bd", function()
+  local target = vim.api.nvim_get_current_buf()
+  local alt = vim.fn.bufnr("#")
+  -- Find a fallback: alternate buffer if listed, otherwise next listed buffer
+  local fallback = (alt > 0 and vim.fn.buflisted(alt) == 1 and alt ~= target) and alt or nil
+  if not fallback then
+    for _, b in ipairs(vim.api.nvim_list_bufs()) do
+      if vim.fn.buflisted(b) == 1 and b ~= target then
+        fallback = b
+        break
+      end
+    end
+  end
+  -- Switch every window showing the target buffer away before deleting
+  for _, win in ipairs(vim.api.nvim_list_wins()) do
+    if vim.api.nvim_win_get_buf(win) == target then
+      if fallback then
+        vim.api.nvim_win_set_buf(win, fallback)
+      else
+        vim.cmd("enew")  -- last buffer: open a new empty one
+      end
+    end
+  end
+  vim.cmd("bdelete " .. target)
+end, { desc = "Delete buffer without closing window" })
 
 -- GitHub Copilot has been removed; AI assistance is now provided by Claude.
 -- Use Avante.nvim (<leader>aa) or the Claude CLI (<leader>gcs) for AI assistance.

--- a/lua/plugins/nvim-tree.lua
+++ b/lua/plugins/nvim-tree.lua
@@ -45,5 +45,32 @@ return {
         dotfiles = true,
       },
     }
+
+    -- Close tree/terminal when quitting would leave them as the only windows.
+    -- Prevents nvim-tree expanding to full-width after the last editor window closes.
+    vim.api.nvim_create_autocmd("QuitPre", {
+      group = vim.api.nvim_create_augroup("ide_layout", { clear = true }),
+      callback = function()
+        local cur_win = vim.api.nvim_get_current_win()
+        -- Collect non-float windows that will remain after this quit
+        local remaining = {}
+        for _, win in ipairs(vim.api.nvim_list_wins()) do
+          if vim.api.nvim_win_get_config(win).relative == "" and win ~= cur_win then
+            table.insert(remaining, win)
+          end
+        end
+        -- If every remaining window is tree or terminal chrome, close them all
+        if #remaining == 0 then return end
+        for _, win in ipairs(remaining) do
+          local buf = vim.api.nvim_win_get_buf(win)
+          if vim.bo[buf].filetype ~= "NvimTree" and vim.bo[buf].buftype ~= "terminal" then
+            return  -- a real editor window will survive; do nothing
+          end
+        end
+        for _, win in ipairs(remaining) do
+          pcall(vim.api.nvim_win_close, win, false)
+        end
+      end,
+    })
   end,
 }

--- a/openspec/changes/archive/2026-06-05-add-ide-layout/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-05-add-ide-layout/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-05

--- a/openspec/changes/archive/2026-06-05-add-ide-layout/design.md
+++ b/openspec/changes/archive/2026-06-05-add-ide-layout/design.md
@@ -1,0 +1,66 @@
+# Design: Add IDE Layout
+
+## Context
+
+Today the pieces of an IDE workspace exist independently:
+
+- nvim-tree opens left at width 30 (`lua/plugins/nvim-tree.lua`), toggled with `<C-t>`/`<leader>n`.
+- A hand-rolled terminal toggle (`lua/keymaps.lua:69-88`, `<leader>t`) keeps one persistent shell in `term_buf` — closing the window leaves the buffer/process running; reopening re-displays it.
+- `splitbelow`/`splitright` are set (`lua/options.lua:22-23`).
+- Glow, which-key, Conjure HUD, and the Claude CLI scratch window are all floating windows that render above splits.
+
+Two layout-stability defects:
+1. `toggle_terminal` uses a plain `split` from the focused window — pressed inside the tree it opens a 30-col terminal in the tree column.
+2. Closing the current buffer (`:bd`) or last editor window (`:q`) makes nvim-tree expand to full width, destroying the layout.
+
+Target layout (VS Code-style full-width bottom panel):
+
+```
+┌────────────┬───────────────────┐
+│  nvim-tree │      editor       │
+├────────────┴───────────────────┤
+│   terminal (full width, 15)    │
+└────────────────────────────────┘
+```
+
+## Goals / Non-Goals
+
+**Goals:**
+- One keystroke (`<leader>L`) assembles tree + editor + terminal, idempotently, focus returning to the editor.
+- Terminal toggle is focus-independent and full-width; its height is stable across window re-equalization.
+- Buffer/window close operations no longer collapse the layout.
+- Minimum custom code; zero new plugins.
+
+**Non-Goals:**
+- No startup autocmd — layout is on-demand only (quick edits and `git commit` stay unaffected).
+- No managed "bottom slot" that swaps shell ↔ REPL. Conjure stays a float; iron.nvim/GHCi keep their own windows. (If iron's 40-line split ever annoys, `iron.view.bottom(40)` → `bottom(15)` in `lua/plugins/dotnet.lua:29` is a later one-liner.)
+- No changes to floating UIs — they already render above splits.
+- No session persistence of the layout.
+
+## Decisions
+
+**1. Full-width bottom terminal via `botright split` (vs right-side-only panel)**
+A `botright` horizontal split is focus-independent by construction — it always spans the full editor width at the bottom, no matter which window invokes it. The right-side-only (IntelliJ-style) variant requires "find the main editor window first" logic. User explicitly accepted full-width for less code. This one-word change also fixes defect 1.
+
+**2. Extend the hand-rolled toggle (vs toggleterm.nvim / edgy.nvim)**
+The existing ~20-line toggle already has the hard part right (persistent buffer reuse). toggleterm adds a plugin dependency for the same behavior; edgy is a full layout manager. Both rejected as heavier than the ~40 lines of Lua this needs.
+
+**3. `winfixheight` on the terminal window**
+Set when the window is created so opening/closing other splits doesn't re-equalize the 15-line panel.
+
+**4. `ide_layout()` lives in `lua/keymaps.lua` beside `toggle_terminal` (vs new `lua/config/layout.lua` module)**
+It shares `term_buf` state with the toggle; a separate module would need to export/import that state. At ~12 lines it doesn't warrant a module. Assembly order: record current window → `NvimTreeOpen` (idempotent) → ensure terminal visible (reuse the window-scan loop; `stopinsert` after opening) → restore focus to the recorded window, falling back to `wincmd t` + `wincmd l` when the original window was the tree or terminal.
+
+**5. Layout-preserving delete as a `:Bd` user command (vs bufdelete.nvim/mini.bufremove plugin)**
+~10 lines: switch every window showing the target buffer to an alternate/next listed buffer (or a fresh empty one), then `:bdelete`. Plugin rejected per minimal-dependency convention. Plain `:bd` remains available and unpatched — `:Bd` is opt-in.
+
+**6. Last-window handling via `QuitPre` autocmd in nvim-tree's plugin config**
+On `QuitPre`, if the windows remaining after the quit would be only nvim-tree (and/or the terminal panel), close them too so Neovim exits instead of leaving a full-width tree. Lives in `lua/plugins/nvim-tree.lua`'s `config` function, next to the plugin it protects. This is the repo's first autocmd: use `vim.api.nvim_create_autocmd` with a named augroup (`ide_layout`) to set the pattern for future ones.
+
+## Risks / Trade-offs
+
+- [`QuitPre` fires for floats and `:wq` too; over-eager closing could exit nvim unintentionally] → Guard: only act when every other window is nvim-tree or the known `term_buf`; ignore floating windows (`nvim_win_get_config(win).relative ~= ""`).
+- [Repo previously had zero autocmds; this introduces runtime event handling] → Keep it to one narrowly-scoped autocmd in a named augroup, documented in the architecture notes.
+- [`:Bd` is opt-in; muscle-memory `:bd` still collapses the layout] → Documented in navigation guide + cheatsheet; remapping `:bd` itself via cabbrev rejected as too magical.
+- [Full-width terminal sits under the tree, stealing 15 lines of tree height] → Accepted explicitly by user (VS Code-style trade-off).
+- [iron.nvim REPL (40 lines) stacking on the 15-line shell squeezes the editor] → Out of scope; documented one-line mitigation in Non-Goals.

--- a/openspec/changes/archive/2026-06-05-add-ide-layout/proposal.md
+++ b/openspec/changes/archive/2026-06-05-add-ide-layout/proposal.md
@@ -1,0 +1,29 @@
+# Add IDE Layout
+
+## Why
+
+The config has all the pieces of an IDE-style workspace (nvim-tree, a persistent terminal toggle) but no way to assemble them in one keystroke, and the layout is fragile: the terminal split opens inside the tree column when focus is in the tree, and closing a buffer (`:bd`) or the last editor window (`:q`) collapses the layout, leaving nvim-tree expanded to full width.
+
+## What Changes
+
+- Terminal toggle (`<leader>t`) opens a **full-width bottom split** (`botright`) regardless of which window has focus, with `winfixheight` so other splits don't re-equalize it. Fixes the latent bug where the terminal opens 30 cols wide inside the tree column.
+- New `<leader>L` keymap assembles the IDE layout in one keystroke: nvim-tree left, editor right, full-width terminal bottom — idempotent, returning focus to the editor.
+- New `:Bd` layout-preserving buffer delete: the window switches to another buffer before deletion, so the window layout (and the tree's width) survives.
+- New autocmd closes nvim-tree when it would be left as the last remaining window after `:q`.
+- REPLs are explicitly untouched: Conjure stays a float (HUD); iron.nvim/GHCi keep their own windows. Floating UIs (Glow, which-key, cheatsheet popups) are unaffected by design.
+
+## Capabilities
+
+### New Capabilities
+- `ide-layout`: One-keystroke IDE-style workspace assembly (tree + editor + full-width bottom terminal), focus-independent full-width terminal toggle with persistent shell, and layout stability under buffer/window close (`:Bd`, last-window autocmd).
+
+### Modified Capabilities
+
+None — no existing spec covers terminal toggle or tree navigation (verified against `openspec/specs/`).
+
+## Impact
+
+- `lua/keymaps.lua` — terminal section: `botright split` + `winfixheight` fix, new `ide_layout()` + `<leader>L`, new `:Bd` command.
+- `lua/plugins/nvim-tree.lua` — last-window autocmd (first autocmd in the repo; `nvim_create_autocmd` + named augroup).
+- Docs: `docs/modules/ROOT/pages/editor/keybindings.adoc`, `docs/modules/ROOT/pages/editor/navigation.adoc`, `cheatsheets/core.md`.
+- No new plugins; no changes to REPL plugins (`lua/plugins/dotnet.lua`, `lua/plugins/lisp.lua`, `lua/plugins/haskell.lua`).

--- a/openspec/changes/archive/2026-06-05-add-ide-layout/specs/ide-layout/spec.md
+++ b/openspec/changes/archive/2026-06-05-add-ide-layout/specs/ide-layout/spec.md
@@ -1,0 +1,68 @@
+# Spec: ide-layout
+
+## ADDED Requirements
+
+### Requirement: Full-width terminal toggle
+The terminal toggle (`<leader>t`) SHALL open the terminal in a full-width split at the bottom of the editor (`botright`), regardless of which window has focus when invoked.
+
+#### Scenario: Toggle from the file tree
+- **WHEN** the cursor is in the nvim-tree window and `<leader>t` is pressed
+- **THEN** the terminal opens as a full-width bottom split, not inside the tree column
+
+#### Scenario: Toggle from an editor window
+- **WHEN** the cursor is in an editor window and `<leader>t` is pressed
+- **THEN** the terminal opens as a full-width bottom split below all vertical splits
+
+### Requirement: Persistent shell across toggles
+The terminal toggle SHALL reuse a single shell buffer: closing the terminal window MUST NOT terminate the shell process, and reopening MUST redisplay the same buffer with its scrollback, history, and any running job intact.
+
+#### Scenario: Toggle off and on
+- **WHEN** the terminal is toggled closed and then toggled open again
+- **THEN** the same shell session is shown with prior scrollback preserved
+
+#### Scenario: Shell exited by user
+- **WHEN** the user exits the shell (or wipes the terminal buffer) and toggles the terminal open
+- **THEN** a new shell is started
+
+### Requirement: Stable terminal height
+The terminal window SHALL keep its height (15 lines) when other windows are opened or closed (`winfixheight`).
+
+#### Scenario: Opening another split
+- **WHEN** the terminal is visible and a new horizontal split is opened elsewhere
+- **THEN** the terminal window remains 15 lines tall
+
+### Requirement: One-keystroke IDE layout assembly
+A keymap (`<leader>L`) SHALL assemble the IDE layout — nvim-tree on the left, editor on the right, full-width terminal at the bottom — and return focus to the editor window. The operation MUST be idempotent: invoking it when the layout (or part of it) already exists SHALL NOT create duplicate windows.
+
+#### Scenario: Assemble from a plain editor session
+- **WHEN** `<leader>L` is pressed in a session with only an editor window
+- **THEN** nvim-tree opens on the left, the terminal opens full-width at the bottom, and focus is in the editor window
+
+#### Scenario: Invoke when layout already assembled
+- **WHEN** `<leader>L` is pressed while tree and terminal are already visible
+- **THEN** no additional windows are created and focus is in the editor window
+
+### Requirement: Layout-preserving buffer delete
+A `:Bd` user command SHALL delete the current buffer while keeping its window open (showing another listed buffer, or an empty one), so the window layout survives.
+
+#### Scenario: Delete a buffer in the assembled layout
+- **WHEN** `:Bd` is run in the editor window while tree and terminal are visible
+- **THEN** the buffer is deleted, the editor window remains, and nvim-tree stays at its configured width
+
+### Requirement: Tree never left as the last window
+When quitting would leave only the nvim-tree window (and/or the terminal panel) on screen, those windows SHALL be closed as well so nvim-tree never remains expanded to full width.
+
+#### Scenario: Quit the last editor window
+- **WHEN** `:q` is run in the only editor window while nvim-tree (and optionally the terminal) is open
+- **THEN** Neovim does not leave nvim-tree as a lone full-width window
+
+#### Scenario: Quit with multiple editor windows open
+- **WHEN** `:q` is run in one of several editor windows
+- **THEN** only that window closes and the remaining layout is untouched
+
+### Requirement: Floating UIs unaffected
+The IDE layout SHALL NOT alter the behavior or extent of floating windows (Glow previews, which-key hints, Conjure HUD/eval popups, cheatsheet popups, Claude CLI scratch window).
+
+#### Scenario: Popup over the assembled layout
+- **WHEN** a Glow preview or which-key hint is triggered while the IDE layout is assembled
+- **THEN** the float renders above the splits at its usual size and position

--- a/openspec/changes/archive/2026-06-05-add-ide-layout/tasks.md
+++ b/openspec/changes/archive/2026-06-05-add-ide-layout/tasks.md
@@ -1,0 +1,27 @@
+# Tasks: Add IDE Layout
+
+## 1. Terminal toggle fixes (lua/keymaps.lua)
+
+- [x] 1.1 Change `toggle_terminal` to use `botright split` so the terminal opens full-width regardless of focused window
+- [x] 1.2 Set `winfixheight` on the terminal window when created (keep `resize 15`, buffer reuse, `startinsert`)
+
+## 2. IDE layout assembly (lua/keymaps.lua)
+
+- [x] 2.1 Add `ide_layout()`: record current window → `NvimTreeOpen` → ensure terminal visible (reuse window-scan; `stopinsert` after opening) → restore focus to editor window (fallback `wincmd t` + `wincmd l`)
+- [x] 2.2 Add `<leader>L` keymap with desc "IDE layout: tree + editor + terminal"
+
+## 3. Layout stability
+
+- [x] 3.1 Add `:Bd` user command in lua/keymaps.lua: switch windows showing the buffer to alternate/next listed buffer (or empty) before `:bdelete`
+- [x] 3.2 Add `QuitPre` autocmd in lua/plugins/nvim-tree.lua config (augroup `ide_layout`): close nvim-tree/terminal when they would be the only windows left; ignore floating windows
+
+## 4. Documentation
+
+- [x] 4.1 Update docs/modules/ROOT/pages/editor/keybindings.adoc: add `<leader>L` and `:Bd`; note `<leader>t` is now full-width
+- [x] 4.2 Update docs/modules/ROOT/pages/editor/navigation.adoc: rewrite terminal section (full-width, persistent shell), add IDE layout subsection with ASCII diagram, document tree-expansion fixes
+- [x] 4.3 Update cheatsheets/core.md: add `<leader>L` and `:Bd` to the tree/terminal block
+
+## 5. Validation
+
+- [x] 5.1 Run `find . -name '*.lua' -print0 | xargs -0 luac -p` (all Lua syntax-clean)
+- [x] 5.2 Manual verification per spec scenarios: `<leader>L` assembly + idempotency, `<leader>t` from tree (full-width), shell persistence across toggles, `:Bd` keeps layout, `:q` last-window behavior, floats (Glow/which-key/Conjure HUD) unaffected, terminal height stable when splitting

--- a/openspec/specs/ide-layout/spec.md
+++ b/openspec/specs/ide-layout/spec.md
@@ -1,0 +1,71 @@
+# ide-layout Specification
+
+## Purpose
+Define the expected IDE layout experience in Neovim: a persistent full-width terminal panel at the bottom, nvim-tree file explorer on the left, and editor windows on the right. Covers terminal toggle behaviour, one-keystroke layout assembly, layout-preserving buffer deletion, and guardrails that keep the layout stable across normal editing operations.
+
+## Requirements
+
+### Requirement: Full-width terminal toggle
+The terminal toggle (`<leader>t`) SHALL open the terminal in a full-width split at the bottom of the editor (`botright`), regardless of which window has focus when invoked.
+
+#### Scenario: Toggle from the file tree
+- **WHEN** the cursor is in the nvim-tree window and `<leader>t` is pressed
+- **THEN** the terminal opens as a full-width bottom split, not inside the tree column
+
+#### Scenario: Toggle from an editor window
+- **WHEN** the cursor is in an editor window and `<leader>t` is pressed
+- **THEN** the terminal opens as a full-width bottom split below all vertical splits
+
+### Requirement: Persistent shell across toggles
+The terminal toggle SHALL reuse a single shell buffer: closing the terminal window MUST NOT terminate the shell process, and reopening MUST redisplay the same buffer with its scrollback, history, and any running job intact.
+
+#### Scenario: Toggle off and on
+- **WHEN** the terminal is toggled closed and then toggled open again
+- **THEN** the same shell session is shown with prior scrollback preserved
+
+#### Scenario: Shell exited by user
+- **WHEN** the user exits the shell (or wipes the terminal buffer) and toggles the terminal open
+- **THEN** a new shell is started
+
+### Requirement: Stable terminal height
+The terminal window SHALL keep its height (15 lines) when other windows are opened or closed (`winfixheight`).
+
+#### Scenario: Opening another split
+- **WHEN** the terminal is visible and a new horizontal split is opened elsewhere
+- **THEN** the terminal window remains 15 lines tall
+
+### Requirement: One-keystroke IDE layout assembly
+A keymap (`<leader>L`) SHALL assemble the IDE layout — nvim-tree on the left, editor on the right, full-width terminal at the bottom — and return focus to the editor window. The operation MUST be idempotent: invoking it when the layout (or part of it) already exists SHALL NOT create duplicate windows.
+
+#### Scenario: Assemble from a plain editor session
+- **WHEN** `<leader>L` is pressed in a session with only an editor window
+- **THEN** nvim-tree opens on the left, the terminal opens full-width at the bottom, and focus is in the editor window
+
+#### Scenario: Invoke when layout already assembled
+- **WHEN** `<leader>L` is pressed while tree and terminal are already visible
+- **THEN** no additional windows are created and focus is in the editor window
+
+### Requirement: Layout-preserving buffer delete
+A `:Bd` user command SHALL delete the current buffer while keeping its window open (showing another listed buffer, or an empty one), so the window layout survives.
+
+#### Scenario: Delete a buffer in the assembled layout
+- **WHEN** `:Bd` is run in the editor window while tree and terminal are visible
+- **THEN** the buffer is deleted, the editor window remains, and nvim-tree stays at its configured width
+
+### Requirement: Tree never left as the last window
+When quitting would leave only the nvim-tree window (and/or the terminal panel) on screen, those windows SHALL be closed as well so nvim-tree never remains expanded to full width.
+
+#### Scenario: Quit the last editor window
+- **WHEN** `:q` is run in the only editor window while nvim-tree (and optionally the terminal) is open
+- **THEN** Neovim does not leave nvim-tree as a lone full-width window
+
+#### Scenario: Quit with multiple editor windows open
+- **WHEN** `:q` is run in one of several editor windows
+- **THEN** only that window closes and the remaining layout is untouched
+
+### Requirement: Floating UIs unaffected
+The IDE layout SHALL NOT alter the behavior or extent of floating windows (Glow previews, which-key hints, Conjure HUD/eval popups, cheatsheet popups, Claude CLI scratch window).
+
+#### Scenario: Popup over the assembled layout
+- **WHEN** a Glow preview or which-key hint is triggered while the IDE layout is assembled
+- **THEN** the float renders above the splits at its usual size and position

--- a/testdocs/ide-layout-verification.md
+++ b/testdocs/ide-layout-verification.md
@@ -1,0 +1,22 @@
+# IDE Layout — Manual Verification Checklist
+
+## Setup
+
+Open Neovim with a file: `nvim <some-file>`
+
+---
+
+## Scenarios
+
+- [x] **`<leader>L` assembles layout** — tree opens left, terminal opens full-width at bottom, focus lands in editor
+- [x] **`<leader>L` is idempotent** — press again; no duplicate windows
+- [x] **`<leader>t` from inside the tree** — terminal opens full-width (not 30-col inside the tree column)
+- [x] **Shell persists across toggles** — toggle terminal off (`<leader>t`), toggle back on; same shell session, history intact
+- [x] **`:Bd` keeps the layout** — open two files, run `:Bd` on one; window stays open showing the other file, tree width unchanged
+- [x] **`:q` last editor exits cleanly** — with layout assembled, `:q` the editor; Neovim exits, no full-width tree left behind
+- [x] **Floats unaffected** — trigger `:Glow`, `<leader>?` cheatsheet; popups render over the layout normally
+- [x] **Terminal height stable** — open another split (`:split`); terminal stays 15 lines tall
+
+---
+
+_Change: `add-ide-layout` | Branch: `feat/add-ide-layout`_


### PR DESCRIPTION
…nd layout stability

- <leader>L assembles tree + editor + full-width bottom terminal idempotently
- Terminal toggle (botright split + winfixheight) is now focus-independent; fixes the bug where <leader>t opened a 30-col terminal inside the tree column
- :Bd layout-preserving buffer delete keeps windows open when switching buffers
- QuitPre autocmd closes tree/terminal when they'd be the last remaining windows
- Docs: keybindings.adoc, navigation.adoc, cheatsheets/core.md updated
- OpenSpec: add-ide-layout archived; openspec/specs/ide-layout/spec.md created